### PR TITLE
Add stdio header for linux builds

### DIFF
--- a/src/Platform_unix.cpp
+++ b/src/Platform_unix.cpp
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <sys/resource.h>
 #include <uv.h>
-
+#include <stdio.h>
 
 #include "Platform.h"
 #include "version.h"

--- a/src/log/ConsoleLog.cpp
+++ b/src/log/ConsoleLog.cpp
@@ -35,7 +35,7 @@
 
 #include "log/ConsoleLog.h"
 #include "log/Log.h"
-
+#include <stdio.h>
 
 ConsoleLog::ConsoleLog(bool colors) :
     m_colors(colors)

--- a/src/log/FileLog.cpp
+++ b/src/log/FileLog.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
+#include <stdio.h>
 
 #include "log/FileLog.h"
 


### PR DESCRIPTION
Currently cmake builds on linux fail without those headers. This
commit fixes that.