### PR TITLE
Fixing failed build on MSVC 2017 Win64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ if (WITH_HTTPD)
     find_package(MHD)
 
     if (MHD_FOUND)
-        include_directories(${MHD_INCLUDE_DIRS})
+        include_directories(${MHD_INCLUDE_DIR})
         set(HTTPD_SOURCES src/api/Httpd.h src/api/Httpd.cpp)
     else()
         message(FATAL_ERROR "microhttpd NOT found: use `-DWITH_HTTPD=OFF` to build without http deamon support")

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -42,6 +42,7 @@
 #include "rapidjson/error/en.h"
 #include "rapidjson/filereadstream.h"
 #include "version.h"
+#include <fcntl.h>
 
 
 #ifndef ARRAY_SIZE

--- a/src/log/FileLog.cpp
+++ b/src/log/FileLog.cpp
@@ -30,7 +30,8 @@
 
 
 #include "log/FileLog.h"
-
+#include <uv.h>
+#include <fcntl.h>
 
 FileLog::FileLog(const char *fileName)
 {


### PR DESCRIPTION
* Fixing cmake MHD_INCLUDE_DIR to correspond with README
* Adding missing headers to Options/FileLog to compile on MSVC 2017 Win64