### PR TITLE
add missing stdio header

### DIFF
--- a/src/Platform_mac.cpp
+++ b/src/Platform_mac.cpp
@@ -21,7 +21,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <stdio.h>
 #include <stdlib.h>
 #include <sys/resource.h>
 #include <uv.h>


### PR DESCRIPTION
this missing header threw exception on Mac OSX 10.10.5
```
xmrig/src/Platform_mac.cpp:48:5: error: use of undeclared identifier 'snprintf'
    snprintf(buf, max, "%s/%s (Macintosh; Intel Mac OS X) libuv/%s clang/%d.%d.%d"
    ^
```
