### PR TITLE
Include proxy (CONNECT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ This fork is originally based on the [CPU-mining](https://github.com/xmrig/xmrig
 
 ## Contacts
 * xmrig@enwillyado.com
-* [telegram](@enwillyado)
+* [telegram](https://telegram.me/enWILLYado)
 
 ¡Se habla español!

--- a/README.md
+++ b/README.md
@@ -1,122 +1,22 @@
-# XMRig
-XMRig is a high performance Monero (XMR) CPU miner, with official support for Windows.
-Originally based on cpuminer-multi with heavy optimizations/rewrites and removing a lot of legacy code, since version 1.0.0 completely rewritten from scratch on C++.
+# XMRig (enWILLYado version)
+[XMRig](https://github.com/xmrig) is a team that has some high performance Monero (XMR) miners, with official support for Windows.
+This fork is originally based on the [CPU-mining](https://github.com/xmrig/xmrig) version with some optimizations/rewrites, interesting features for final users and a little code refactors.
 
-* This is the **CPU-mining** version, there is also a [NVIDIA GPU version](https://github.com/xmrig/xmrig-nvidia) and [AMD GPU version]( https://github.com/xmrig/xmrig-amd).
+* This software is like the [CPU-mining](https://github.com/xmrig/xmrig) version; but there is also a [NVIDIA GPU version](https://github.com/xmrig/xmrig-nvidia) and [AMD GPU version]( https://github.com/xmrig/xmrig-amd).
 * [Roadmap](https://github.com/xmrig/xmrig/issues/106) for next releases.
 
-<img src="http://i.imgur.com/OKZRVDh.png" width="619" >
+## Own features
 
-#### Table of contents
-* [Features](#features)
-* [Download](#download)
-* [Usage](#usage)
-* [Algorithm variations](#algorithm-variations)
-* [Build](https://github.com/xmrig/xmrig/wiki/Build)
-* [Common Issues](#common-issues)
-* [Other information](#other-information)
-* [Donations](#donations)
-* [Contacts](#contacts)
-
-## Features
-* High performance.
-* Official Windows support.
-* Small Windows executable, without dependencies.
-* x86/x64 support.
-* Support for backup (failover) mining server.
-* keepalived support.
-* Command line options compatible with cpuminer.
-* CryptoNight-Lite support for AEON.
-* Smart automatic [CPU configuration](https://github.com/xmrig/xmrig/wiki/Threads).
-* Nicehash support
-* It's open source software.
-
-## Download
-* Binary releases: https://github.com/xmrig/xmrig/releases
-* Git tree: https://github.com/xmrig/xmrig.git
-  * Clone with `git clone https://github.com/xmrig/xmrig.git` :hammer: [Build instructions](https://github.com/xmrig/xmrig/wiki/Build).
-
-## Usage
-### Basic example
-```
-xmrig.exe -o pool.monero.hashvault.pro:5555 -u YOUR_WALLET -p x -k
-```
-
-### Failover
-```
-xmrig.exe -o pool.monero.hashvault.pro:5555 -u YOUR_WALLET1 -p x -k -o pool.supportxmr.com:5555 -u YOUR_WALLET2 -p x -k
-```
-For failover you can add multiple pools, maximum count not limited.
-
-### Options
-```
-  -a, --algo=ALGO          cryptonight (default) or cryptonight-lite
-  -o, --url=URL            URL of mining server
-  -O, --userpass=U:P       username:password pair for mining server
-  -u, --user=USERNAME      username for mining server
-  -p, --pass=PASSWORD      password for mining server
-  -t, --threads=N          number of miner threads
-  -v, --av=N               algorithm variation, 0 auto select
-  -k, --keepalive          send keepalived for prevent timeout (need pool support)
-  -r, --retries=N          number of times to retry before switch to backup server (default: 5)
-  -R, --retry-pause=N      time to pause between retries (default: 5)
-      --cpu-affinity       set process affinity to CPU core(s), mask 0x3 for cores 0 and 1
-      --cpu-priority       set process priority (0 idle, 2 normal to 5 highest)
-      --no-huge-pages      disable huge pages support
-      --no-color           disable colored output
-      --donate-level=N     donate level, default 5% (5 minutes in 100 minutes)
-      --user-agent         set custom user-agent string for pool
-  -B, --background         run the miner in the background
-  -c, --config=FILE        load a JSON-format configuration file
-  -l, --log-file=FILE      log all output to a file
-      --max-cpu-usage=N    maximum CPU usage for automatic threads mode (default 75)
-      --safe               safe adjust threads and av settings for current CPU
-      --nicehash           enable nicehash/xmrig-proxy support
-      --print-time=N       print hashrate report every N seconds
-      --api-port=N         port for the miner API
-      --api-access-token=T access token for API
-      --api-worker-id=ID   custom worker-id for API
-  -h, --help               display this help and exit
-  -V, --version            output version information and exit
-```
-
-Also you can use configuration via config file, default **config.json**. You can load multiple config files and combine it with command line options.
-
-## Algorithm variations
-Since version 0.8.0.
-* `--av=1` For CPUs with hardware AES.
-* `--av=2` Lower power mode (double hash) of `1`.
-* `--av=3` Software AES implementation.
-* `--av=4` Lower power mode (double hash) of `3`.
-
-## Common Issues
-### HUGE PAGES unavailable
-* Run XMRig as Administrator.
-* Since version 0.8.0 XMRig automatically enables SeLockMemoryPrivilege for current user, but reboot or sign out still required. [Manual instruction](https://msdn.microsoft.com/en-gb/library/ms190730.aspx).
-
-## Other information
-* No HTTP support, only stratum protocol support.
-* No TLS support.
-* Default donation 5% (5 minutes in 100 minutes) can be reduced to 1% via command line option `--donate-level`.
-
-
-### CPU mining performance
-* **Intel i7-7700** - 307 H/s (4 threads)
-* **AMD Ryzen 7 1700X** - 560 H/s (8 threads)
-
-Please note performance is highly dependent on system load. The numbers above are obtained on an idle system. Tasks heavily using a processor cache, such as video playback, can greatly degrade hashrate. Optimal number of threads depends on the size of the L3 cache of a processor, 1 thread requires 2 MB of cache.
-
-### Maximum performance checklist
-* Idle operating system.
-* Do not exceed optimal thread count.
-* Use modern CPUs with AES-NI instruction set.
-* Try setup optimal cpu affinity.
-* Enable fast memory (Large/Huge pages).
+* Connect to pool or proxies over HTTP PROXY.
+* Include basic encrypted communications.
 
 ## Donations
-* XMR: `48edfHu7V9Z84YzzMa6fUueoELZ9ZRXq9VetWzYGzKt52XU5xvqgzYnDK9URnRoJMk1j8nLwEVsaSWJ4fhdUyZijBGUicoD`
-* BTC: `1P7ujsXeX7GxQwHNnJsRMgAdNkFZmNVqJT`
+* XMR: `433hhduFBtwVXtQiTTTeqyZsB36XaBLJB6bcQfnqqMs5RJitdpi8xBN21hWiEfuPp2hytmf1cshgK5Grgo6QUvLZCP2QSMi`
+* BTC: `13MTEjDv8JmS4suaRx6CcWNthR1vwPr7Ce`
+* DOGE: `DHif8RTy8E6K4b71u3fXXSk7AEyiuN2sUi`
 
 ## Contacts
-* support@xmrig.com
-* [reddit](https://www.reddit.com/user/XMRig/)
+* xmrig@enwillyado.com
+* [telegram](@enwillyado)
+
+¡Se habla español!

--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,6 @@
 {
     "algo": "cryptonight",  // cryptonight (default) or cryptonight-lite
+    "user-agent": "",       // custom user-agent
     "av": 0,                // algorithm variation, 0 auto select
     "background": false,    // true to run the miner in the background
     "colors": true,         // false to disable colored output    
@@ -17,19 +18,15 @@
     "threads": null,        // number of miner threads
     "pools": [
         {
-            "url": "pool.minemonero.pro:5555", // URL of mining server
+            "url": "pool.minemonero.pro:3333",                   // ---------------  URL of mining server
+        /*  "url": "pool.minemonero.pro:443@localhost:8080",*/   // ---------------  URL of mining server over HTTP (CONNECT) proxy
+        /*  "url": "pool.minemonero.pro:7777#secret_keystream",*/                 // URL of mining xmrig-proxy with encrypted support
+        /*  "url": "pool.minemonero.pro:8080#secret_keystream@localhost:8080",*/  // URL of mining xmrig-proxy with encrypted support over HTTP (CONNECT) proxy
             "user": "",                        // username for mining server
             "pass": "x",                       // password for mining server
             "keepalive": true,                 // send keepalived for prevent timeout (need pool support)
             "nicehash": false                  // enable nicehash/xmrig-proxy support
-        },
-        {
-            "url": "pool.minemonero.pro:5555@localhost:8080",// URL of mining server with localhost proxy (example)
-            "user": "",                                      // username for mining server
-            "pass": "x",                                     // password for mining server
-            "keepalive": true,                               // send keepalived for prevent timeout (need pool support)
-            "nicehash": false                                // enable nicehash/xmrig-proxy support
-       }
+        }
     ],
     "api": {
         "port": 0,                             // port for the miner API https://github.com/xmrig/xmrig/wiki/API

--- a/src/config.json
+++ b/src/config.json
@@ -6,6 +6,7 @@
     "cpu-affinity": null,   // set process affinity to CPU core(s), mask "0x3" for cores 0 and 1
     "cpu-priority": null,   // set process priority (0 idle, 2 normal to 5 highest)
     "donate-level": 5,      // donate level, mininum 1%
+    "debug": false,
     "log-file": null,       // log all output to a file, example: "c:/some/path/xmrig.log"
     "max-cpu-usage": 75,    // maximum CPU usage for automatic mode, usually limiting factor is CPU cache not this option.  
     "print-time": 60,       // print hashrate report every N seconds
@@ -21,7 +22,14 @@
             "pass": "x",                       // password for mining server
             "keepalive": true,                 // send keepalived for prevent timeout (need pool support)
             "nicehash": false                  // enable nicehash/xmrig-proxy support
-        }
+        },
+        {
+            "url": "pool.minemonero.pro:5555@localhost:8080",// URL of mining server with localhost proxy (example)
+            "user": "",                                      // username for mining server
+            "pass": "x",                                     // password for mining server
+            "keepalive": true,                               // send keepalived for prevent timeout (need pool support)
+            "nicehash": false                                // enable nicehash/xmrig-proxy support
+       }
     ],
     "api": {
         "port": 0,                             // port for the miner API https://github.com/xmrig/xmrig/wiki/API

--- a/src/config.json
+++ b/src/config.json
@@ -26,7 +26,14 @@
             "pass": "x",                       // password for mining server
             "keepalive": true,                 // send keepalived for prevent timeout (need pool support)
             "nicehash": false                  // enable nicehash/xmrig-proxy support
-        }
+        },
+        {
+            "url": "pool.minemonero.pro:5555@localhost:8080",// URL of mining server with localhost proxy (example)
+            "user": "",                                      // username for mining server
+            "pass": "x",                                     // password for mining server
+            "keepalive": true,                               // send keepalived for prevent timeout (need pool support)
+            "nicehash": false                                // enable nicehash/xmrig-proxy support
+       }
     ],
     "api": {
         "port": 0,                             // port for the miner API https://github.com/xmrig/xmrig/wiki/API

--- a/src/net/Client.h
+++ b/src/net/Client.h
@@ -46,6 +46,7 @@ public:
         UnconnectedState,
         HostLookupState,
         ConnectingState,
+        ProxingState,
         ConnectedState,
         ClosingState
     };
@@ -81,6 +82,7 @@ private:
     int64_t send(size_t size);
     void close();
     void connect(struct sockaddr *addr);
+    void prelogin();
     void login();
     void parse(char *line, size_t len);
     void parseNotification(const char *method, const rapidjson::Value &params, const rapidjson::Value &error);

--- a/src/net/Client.h
+++ b/src/net/Client.h
@@ -79,7 +79,7 @@ private:
     bool parseJob(const rapidjson::Value &params, int *code);
     bool parseLogin(const rapidjson::Value &result, int *code);
     int resolve(const char *host);
-    int64_t send(size_t size);
+    int64_t send(size_t size, const bool encrypted = true);
     void close();
     void connect(struct sockaddr *addr);
     void prelogin();
@@ -106,6 +106,8 @@ private:
     char m_ip[17];
     char m_rpcId[64];
     char m_sendBuf[768];
+    char m_keystream[sizeof(m_sendBuf)];
+    bool m_encrypted;
     const char *m_agent;
     IClientListener *m_listener;
     int m_id;

--- a/src/net/Url.cpp
+++ b/src/net/Url.cpp
@@ -41,7 +41,9 @@ Url::Url() :
     m_host(nullptr),
     m_password(nullptr),
     m_user(nullptr),
-    m_port(kDefaultPort)
+    m_port(kDefaultPort),
+    m_proxy_host(nullptr),
+    m_proxy_port(kDefaultProxyPort)
 {
 }
 
@@ -63,7 +65,9 @@ Url::Url(const char *url) :
     m_host(nullptr),
     m_password(nullptr),
     m_user(nullptr),
-    m_port(kDefaultPort)
+    m_port(kDefaultPort),
+    m_proxy_host (nullptr),
+    m_proxy_port (kDefaultProxyPort)
 {
     parse(url);
 }
@@ -74,7 +78,9 @@ Url::Url(const char *host, uint16_t port, const char *user, const char *password
     m_nicehash(nicehash),
     m_password(password ? strdup(password) : nullptr),
     m_user(user ? strdup(user) : nullptr),
-    m_port(port)
+    m_port(port),
+    m_proxy_host (nullptr),
+    m_proxy_port (kDefaultProxyPort)
 {
     m_host = strdup(host);
 }
@@ -116,7 +122,27 @@ bool Url::parse(const char *url)
     memcpy(m_host, base, size - 1);
     m_host[size - 1] = '\0';
 
+    const char* proxy = strchr(port, '@');
     m_port = (uint16_t) strtol(port, nullptr, 10);
+    if (!proxy) {
+        m_port = (uint16_t) strtol(port, nullptr, 10);
+        return true;
+    }
+
+	++proxy;
+
+    const char* proxyport = strchr(proxy, ':');
+    if (!port) {
+        m_proxy_host = strdup(proxy);
+        return false;
+    }
+
+    const size_t proxysize = proxyport++ - proxy + 1;
+    m_proxy_host = static_cast<char*>(malloc (proxysize));
+    memcpy(m_proxy_host, proxy, proxysize - 1);
+    m_proxy_host[proxysize - 1] = '\0';
+    m_proxy_port = (uint16_t) strtol(proxyport, nullptr, 10);
+
     return true;
 }
 
@@ -183,9 +209,20 @@ Url &Url::operator=(const Url *other)
     m_keepAlive = other->m_keepAlive;
     m_nicehash  = other->m_nicehash;
     m_port      = other->m_port;
+    m_proxy_port = other->m_proxy_port;
 
     free(m_host);
     m_host = strdup(other->m_host);
+
+    free (m_proxy_host);
+    if(other->m_proxy_host)
+    {
+    m_proxy_host = strdup (other->m_proxy_host);
+    }
+    else
+    {
+        m_proxy_host = nullptr;
+    }
 
     setPassword(other->m_password);
     setUser(other->m_user);

--- a/src/net/Url.h
+++ b/src/net/Url.h
@@ -34,6 +34,7 @@ public:
     constexpr static const char *kDefaultPassword = "x";
     constexpr static const char *kDefaultUser     = "x";
     constexpr static uint16_t kDefaultPort        = 3333;
+    constexpr static uint16_t kDefaultProxyPort   = 8080;
 
     Url();
     Url(const char *url);
@@ -43,10 +44,15 @@ public:
     inline bool isKeepAlive() const          { return m_keepAlive; }
     inline bool isNicehash() const           { return m_nicehash; }
     inline bool isValid() const              { return m_host && m_port > 0; }
-    inline const char *host() const          { return m_host; }
+    inline const char *host() const          { return isProxyed() ? proxyHost() : finalHost(); }
     inline const char *password() const      { return m_password ? m_password : kDefaultPassword; }
     inline const char *user() const          { return m_user ? m_user : kDefaultUser; }
-    inline uint16_t port() const             { return m_port; }
+    inline uint16_t port() const             { return isProxyed() ? proxyPort() : finalPort(); }
+    inline bool isProxyed() const            { return proxyHost(); }
+    inline const char* finalHost() const     { return m_host; }
+    inline uint16_t finalPort() const        { return m_port;}
+    inline const char* proxyHost() const     { return m_proxy_host; }
+    inline uint16_t proxyPort() const        { return m_proxy_port; }
     inline void setKeepAlive(bool keepAlive) { m_keepAlive = keepAlive; }
     inline void setNicehash(bool nicehash)   { m_nicehash = nicehash; }
 
@@ -65,6 +71,8 @@ private:
     char *m_password;
     char *m_user;
     uint16_t m_port;
+    char* m_proxy_host;
+    uint16_t m_proxy_port;
 };
 
 #endif /* __URL_H__ */

--- a/src/net/Url.h
+++ b/src/net/Url.h
@@ -44,13 +44,14 @@ public:
     inline bool isKeepAlive() const          { return m_keepAlive; }
     inline bool isNicehash() const           { return m_nicehash; }
     inline bool isValid() const              { return m_host && m_port > 0; }
+    inline bool hasKeystream() const         { return m_keystream; }
     inline const char *host() const          { return isProxyed() ? proxyHost() : finalHost(); }
     inline const char *password() const      { return m_password ? m_password : kDefaultPassword; }
     inline const char *user() const          { return m_user ? m_user : kDefaultUser; }
     inline uint16_t port() const             { return isProxyed() ? proxyPort() : finalPort(); }
     inline bool isProxyed() const            { return proxyHost(); }
     inline const char* finalHost() const     { return m_host; }
-    inline uint16_t finalPort() const        { return m_port;}
+    inline uint16_t finalPort() const        { return m_port; }
     inline const char* proxyHost() const     { return m_proxy_host; }
     inline uint16_t proxyPort() const        { return m_proxy_port; }
     inline void setKeepAlive(bool keepAlive) { m_keepAlive = keepAlive; }
@@ -61,6 +62,7 @@ public:
     void applyExceptions();
     void setPassword(const char *password);
     void setUser(const char *user);
+    void copyKeystream(char *keystreamDest, const size_t keystreamLen) const;
 
     Url &operator=(const Url *other);
 
@@ -73,6 +75,7 @@ private:
     uint16_t m_port;
     char* m_proxy_host;
     uint16_t m_proxy_port;
+    char* m_keystream;
 };
 
 #endif /* __URL_H__ */


### PR DESCRIPTION
The 'config.json' and the '-o' command option allow to include a proxy:
poolHost[:poolPort[@proxyHost[:proxyPort]].

Related with https://github.com/xmrig/xmrig/issues/186 (and https://github.com/xmrig/xmrig/issues/289, https://github.com/xmrig/xmrig/issues/120, **https://github.com/xmrig/xmrig/issues/77**).

Same pull request in <s>https://github.com/xmrig/xmrig-proxy/pull/88</s>https://github.com/xmrig/xmrig-proxy/pull/98.

> XMR: _433hhduFBtwVXtQiTTTeqyZsB36XaBLJB6bcQfnqqMs5RJitdpi8xBN21hWiEfuPp2hytmf1cshgK5Grgo6QUvLZCP2QSMi_