### PR TITLE
Changes for the Monero v1 PoW

### DIFF
--- a/src/crypto/CryptoNight.h
+++ b/src/crypto/CryptoNight.h
@@ -50,9 +50,9 @@ class JobResult;
 class CryptoNight
 {
 public:
-    static bool hash(const Job &job, JobResult &result, cryptonight_ctx *ctx);
+    static bool hash(const Job &job, JobResult &result, cryptonight_ctx *ctx, uint8_t version);
     static bool init(int algo, int variant);
-    static void hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx);
+    static bool hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx, uint8_t version);
 
 private:
     static bool selfTest(int algo);

--- a/src/crypto/CryptoNight_arm.h
+++ b/src/crypto/CryptoNight_arm.h
@@ -344,10 +344,13 @@ static inline void cn_implode_scratchpad(const __m128i *input, __m128i *output)
 }
 
 
-template<size_t ITERATIONS, size_t MEM, size_t MASK, bool SOFT_AES>
-inline void cryptonight_hash(const void *__restrict__ input, size_t size, void *__restrict__ output, cryptonight_ctx *__restrict__ ctx)
+template<size_t ITERATIONS, size_t MEM, size_t MASK, bool SOFT_AES, bool MONERO>
+inline bool cryptonight_hash(const void *__restrict__ input, size_t size, void *__restrict__ output, cryptonight_ctx *__restrict__ ctx, uint8_t version)
 {
     keccak(static_cast<const uint8_t*>(input), (int) size, ctx->state0, 200);
+
+    VARIANT1_CHECK();
+    VARIANT1_INIT(0);
 
     cn_explode_scratchpad<MEM, SOFT_AES>((__m128i*) ctx->state0, (__m128i*) ctx->memory);
 
@@ -374,6 +377,7 @@ inline void cryptonight_hash(const void *__restrict__ input, size_t size, void *
         }
 
         _mm_store_si128((__m128i *) &l0[idx0 & MASK], _mm_xor_si128(bx0, cx));
+        VARIANT1_1(&l0[idx0 & MASK]);
         idx0 = EXTRACT64(cx);
         bx0 = cx;
 
@@ -385,8 +389,10 @@ inline void cryptonight_hash(const void *__restrict__ input, size_t size, void *
         al0 += hi;
         ah0 += lo;
 
+        VARIANT1_2(ah0, 0);
         ((uint64_t*)&l0[idx0 & MASK])[0] = al0;
         ((uint64_t*)&l0[idx0 & MASK])[1] = ah0;
+        VARIANT1_2(ah0, 0);
 
         ah0 ^= ch;
         al0 ^= cl;
@@ -397,14 +403,19 @@ inline void cryptonight_hash(const void *__restrict__ input, size_t size, void *
 
     keccakf(h0, 24);
     extra_hashes[ctx->state0[0] & 3](ctx->state0, 200, static_cast<char*>(output));
+    return true;
 }
 
 
-template<size_t ITERATIONS, size_t MEM, size_t MASK, bool SOFT_AES>
-inline void cryptonight_double_hash(const void *__restrict__ input, size_t size, void *__restrict__ output, struct cryptonight_ctx *__restrict__ ctx)
+template<size_t ITERATIONS, size_t MEM, size_t MASK, bool SOFT_AES, bool MONERO>
+inline bool cryptonight_double_hash(const void *__restrict__ input, size_t size, void *__restrict__ output, struct cryptonight_ctx *__restrict__ ctx, uint8_t version)
 {
     keccak((const uint8_t *) input,        (int) size, ctx->state0, 200);
     keccak((const uint8_t *) input + size, (int) size, ctx->state1, 200);
+
+    VARIANT1_CHECK();
+    VARIANT1_INIT(0);
+    VARIANT1_INIT(1);
 
     const uint8_t* l0 = ctx->memory;
     const uint8_t* l1 = ctx->memory + MEM;
@@ -443,6 +454,8 @@ inline void cryptonight_double_hash(const void *__restrict__ input, size_t size,
 
         _mm_store_si128((__m128i *) &l0[idx0 & MASK], _mm_xor_si128(bx0, cx0));
         _mm_store_si128((__m128i *) &l1[idx1 & MASK], _mm_xor_si128(bx1, cx1));
+        VARIANT1_1(&l0[idx0 & MASK]);
+        VARIANT1_1(&l1[idx1 & MASK]);
 
         idx0 = EXTRACT64(cx0);
         idx1 = EXTRACT64(cx1);
@@ -458,8 +471,10 @@ inline void cryptonight_double_hash(const void *__restrict__ input, size_t size,
         al0 += hi;
         ah0 += lo;
 
+        VARIANT1_2(ah0, 0);
         ((uint64_t*) &l0[idx0 & MASK])[0] = al0;
         ((uint64_t*) &l0[idx0 & MASK])[1] = ah0;
+        VARIANT1_2(ah0, 0);
 
         ah0 ^= ch;
         al0 ^= cl;
@@ -472,8 +487,10 @@ inline void cryptonight_double_hash(const void *__restrict__ input, size_t size,
         al1 += hi;
         ah1 += lo;
 
+        VARIANT1_2(ah1, 1);
         ((uint64_t*) &l1[idx1 & MASK])[0] = al1;
         ((uint64_t*) &l1[idx1 & MASK])[1] = ah1;
+        VARIANT1_2(ah1, 1);
 
         ah1 ^= ch;
         al1 ^= cl;
@@ -488,6 +505,7 @@ inline void cryptonight_double_hash(const void *__restrict__ input, size_t size,
 
     extra_hashes[ctx->state0[0] & 3](ctx->state0, 200, static_cast<char*>(output));
     extra_hashes[ctx->state1[0] & 3](ctx->state1, 200, static_cast<char*>(output) + 32);
+    return true;
 }
 
 #endif /* __CRYPTONIGHT_ARM_H__ */

--- a/src/workers/DoubleWorker.cpp
+++ b/src/workers/DoubleWorker.cpp
@@ -76,6 +76,8 @@ void DoubleWorker::start()
             consumeJob();
         }
 
+        const uint8_t version = m_state->job.size() ? m_state->job.blob()[0] : 0;
+
         while (!Workers::isOutdated(m_sequence)) {
             if ((m_count & 0xF) == 0) {
                 storeStats();
@@ -85,15 +87,15 @@ void DoubleWorker::start()
             *Job::nonce(m_state->blob)                       = ++m_state->nonce1;
             *Job::nonce(m_state->blob + m_state->job.size()) = ++m_state->nonce2;
 
-            CryptoNight::hash(m_state->blob, m_state->job.size(), m_hash, m_ctx);
+            if (CryptoNight::hash(m_state->blob, m_state->job.size(), m_hash, m_ctx, version)) {
+                if (*reinterpret_cast<uint64_t*>(m_hash + 24) < m_state->job.target()) {
+                    Workers::submit(JobResult(m_state->job.poolId(), m_state->job.id(), m_state->nonce1, m_hash, m_state->job.diff()));
+                }
 
-            if (*reinterpret_cast<uint64_t*>(m_hash + 24) < m_state->job.target()) {
-                Workers::submit(JobResult(m_state->job.poolId(), m_state->job.id(), m_state->nonce1, m_hash, m_state->job.diff()));
-            }
-
-            if (*reinterpret_cast<uint64_t*>(m_hash + 32 + 24) < m_state->job.target()) {
-                Workers::submit(JobResult(m_state->job.poolId(), m_state->job.id(), m_state->nonce2, m_hash + 32, m_state->job.diff()));
-            }
+                if (*reinterpret_cast<uint64_t*>(m_hash + 32 + 24) < m_state->job.target()) {
+                    Workers::submit(JobResult(m_state->job.poolId(), m_state->job.id(), m_state->nonce2, m_hash + 32, m_state->job.diff()));
+                }
+            } // print on error ?
 
             std::this_thread::yield();
         }

--- a/src/workers/SingleWorker.cpp
+++ b/src/workers/SingleWorker.cpp
@@ -52,6 +52,8 @@ void SingleWorker::start()
             consumeJob();
         }
 
+        const uint8_t version = m_job.size() ? m_job.blob()[0] : 0;
+
         while (!Workers::isOutdated(m_sequence)) {
             if ((m_count & 0xF) == 0) {
                 storeStats();
@@ -60,7 +62,7 @@ void SingleWorker::start()
             m_count++;
             *m_job.nonce() = ++m_result.nonce;
 
-            if (CryptoNight::hash(m_job, m_result, m_ctx)) {
+            if (CryptoNight::hash(m_job, m_result, m_ctx, version)) {
                 Workers::submit(m_result);
             }
 


### PR DESCRIPTION
Changes for the monero version pow changes. Some implementation notes:

- The arm version needs to be tested.
- All versions access the scratchpad directly after the first tweak, instead of unpacking the simd register. The 11 byte needs to be manipulated, as you can see.
- All versions modify the 64-bit stack value instead of the scratchpad.
- A boolean template argument was added to remove branching from the aeon version.
- The version parameter isn't technically needed (the callee can get this from the input), but I decided to do this because all the other implementations were doing this - in case the miner is used for monero-like variants it can be configured at runtime. The penalty is setting up a register for the call.