### PR TITLE
Bit shifting

### DIFF
--- a/src/crypto/c_blake256.c
+++ b/src/crypto/c_blake256.c
@@ -134,7 +134,7 @@ void blake256_update(state *S, const uint8_t *data, uint64_t datalen) {
         if (S->t[0] == 0) S->t[1]++;
         blake256_compress(S, S->buf);
         data += fill;
-        datalen -= (fill << 3);
+        datalen -= (uint64_t)fill << (uint64_t)3;
         left = 0;
     }
 


### PR DESCRIPTION
This code causes undefined behavior if the N value is higher than 32. You cannot use this code to write a value higher than 0x80000000 into the 'X' variable.