### PR TITLE
Announcement protocol extension

### DIFF
--- a/src/common/net/Client.cpp
+++ b/src/common/net/Client.cpp
@@ -222,6 +222,23 @@ bool Client::close()
     return true;
 }
 
+bool Client::handleAnnouncement(const rapidjson::Value &params)
+{
+    if (!params.IsObject())
+    {
+        return false;
+    }
+
+    if (params.HasMember("message"))
+    {
+        LOG_INFO("[%s] announcement: \"%s\"", m_pool.url(),
+          params["message"].GetString());
+        
+        return true;
+    }
+    
+    return false;
+}
 
 bool Client::isCriticalError(const char *message)
 {
@@ -588,6 +605,9 @@ void Client::parseNotification(const char *method, const rapidjson::Value &param
             m_listener->onJobReceived(this, m_job);
         }
 
+        return;
+    } else if (strcmp(method, "announcement") == 0) {
+        handleAnnouncement(params);
         return;
     }
 

--- a/src/common/net/Client.h
+++ b/src/common/net/Client.h
@@ -84,6 +84,7 @@ private:
     };
 
     bool close();
+    bool handleAnnouncement(const rapidjson::Value &params);
     bool isCriticalError(const char *message);
     bool parseJob(const rapidjson::Value &params, int *code);
     bool parseLogin(const rapidjson::Value &result, int *code);


### PR DESCRIPTION
###### Feature

Allows the pool to show a message in the miner console at any time.

###### Use cases

* Notifying user that pool will be shutting down for maintenance
* Notifying user that they should update their miner due to PoW or protocol change

###### Test case

```js
const net = require('net')

net.createServer(socket => {
  socket.write(JSON.stringify({
    method: 'announcement',
    params: {
      message: 'Hello, World!'
    }
  }) + '\n')
  socket.destroy()
}).listen(1337)
```