### PR TITLE
Fix FileLog (--log-file) fails on non-seekable files

### DIFF
--- a/src/common/log/FileLog.cpp
+++ b/src/common/log/FileLog.cpp
@@ -93,5 +93,5 @@ void FileLog::write(char *data, size_t size)
     uv_fs_t *req = new uv_fs_t;
     req->data = buf.base;
 
-    uv_fs_write(uv_default_loop(), req, m_file, &buf, 1, 0, FileLog::onWrite);
+    uv_fs_write(uv_default_loop(), req, m_file, &buf, 1, -1, FileLog::onWrite);
 }


### PR DESCRIPTION
Using option `--log-file` on non-seekable files such as pipe or tty, will fail; due to using offset `0` for `uv_fs_write(3)`. This patch fixed the bug by setting offset to `-1`, which is means don't change offset.