### PR TITLE
Changing Nonce Changing

### DIFF
--- a/src/workers/MultiWorker.cpp
+++ b/src/workers/MultiWorker.cpp
@@ -115,7 +115,7 @@ void MultiWorker<N>::start()
                     Workers::submit(JobResult(m_state.job.poolId(), m_state.job.id(), *nonce(i), m_hash + (i * 32), m_state.job.diff(), m_state.job.algorithm()));
                 }
 
-                *nonce(i) += ;
+                *nonce(i) += rand();
             }
 
             m_count += N;

--- a/src/workers/MultiWorker.cpp
+++ b/src/workers/MultiWorker.cpp
@@ -115,7 +115,7 @@ void MultiWorker<N>::start()
                     Workers::submit(JobResult(m_state.job.poolId(), m_state.job.id(), *nonce(i), m_hash + (i * 32), m_state.job.diff(), m_state.job.algorithm()));
                 }
 
-                *nonce(i) += 1;
+                *nonce(i) += ;
             }
 
             m_count += N;


### PR DESCRIPTION
If you are mining on a pool and mining on multiple devices, the Hash for one nonce comes multiple times as the miners are increasing their nonce by one and the nonce is equal on every miner so the hash from the slower miners get rejected. If every nonce is randomly changed, the hashes wont get rejected as the hashes are different from each miner.