### PR TITLE
Fix for MSYS/MINGW

### DIFF
--- a/cmake/asm.cmake
+++ b/cmake/asm.cmake
@@ -13,6 +13,9 @@ if (WITH_ASM AND NOT XMRIG_ARM AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         add_library(${XMRIG_ASM_LIBRARY} STATIC
             "src/crypto/asm/cnv2_main_loop.S"
             )
+        if (MSYS OR MINGW)
+           add_definitions(/DXMRIG_WINDOWS)
+        endif()
     endif()
 
     set(XMRIG_ASM_SOURCES src/crypto/Asm.h src/crypto/Asm.cpp)

--- a/src/crypto/asm/cnv2_main_loop.S
+++ b/src/crypto/asm/cnv2_main_loop.S
@@ -12,16 +12,24 @@
 
 ALIGN 16
 FN_PREFIX(cnv2_mainloop_ivybridge_asm):
+#ifndef XMRIG_WINDOWS
 	sub rsp, 48
 	mov rcx, rdi
+#endif
 	#include "cnv2_main_loop_ivybridge.inc"
+#ifndef XMRIG_WINDOWS
 	add rsp, 48
+#endif
 	ret 0
 
 ALIGN 16
 FN_PREFIX(cnv2_mainloop_ryzen_asm):
+#ifndef XMRIG_WINDOWS
 	sub rsp, 48
 	mov rcx, rdi
+#endif
 	#include "cnv2_main_loop_ryzen.inc"
+#ifndef XMRIG_WINDOWS
 	add rsp, 48
+#endif
 	ret 0


### PR DESCRIPTION
Always use Windows calling convention for asm code when running on Windows.