### PR TITLE
Update Asm.cpp

### DIFF
--- a/src/crypto/Asm.cpp
+++ b/src/crypto/Asm.cpp
@@ -67,7 +67,7 @@ xmrig::Assembly xmrig::Asm::parse(const char *assembly, Assembly defaultValue)
 xmrig::Assembly xmrig::Asm::parse(const rapidjson::Value &value, Assembly defaultValue)
 {
     if (value.IsBool()) {
-        return parse(value.IsBool());
+        return parse(value.GetBool());
     }
 
     if (value.IsString()) {


### PR DESCRIPTION
parse(value.IsBool()) should be changed to parse(value.GetBool()), otherwise if the 'asm' parameter in config has a boolean value, it will be parse as 'true' even if it's actually 'false'.