### PR TITLE
syslog(3) logging level fix

### DIFF
--- a/src/common/log/SysLog.cpp
+++ b/src/common/log/SysLog.cpp
@@ -37,7 +37,20 @@ SysLog::SysLog()
 
 void SysLog::message(Level level, const char *fmt, va_list args)
 {
-    vsyslog(static_cast<int>(level), fmt, args);
+    int syslog_priority = LOG_CRIT;
+    switch(level) {
+    case ERR:
+        syslog_priority = LOG_ERR;
+    case WARNING:
+        syslog_priority = LOG_WARNING;
+    case NOTICE:
+        syslog_priority = LOG_NOTICE;
+    case INFO:
+        syslog_priority = LOG_INFO;
+    case DEBUG:
+        syslog_priority = LOG_DEBUG;
+    }
+    vsyslog(syslog_priority, fmt, args);
 }
 
 


### PR DESCRIPTION
The XMRig internal log level is wrongly mapped the `syslog(3)` log level (priority). On a GNU system for example `NOTICE` (2) is mapped to `LOG_CRIT`, and `INFO` (3) is mapped to `LOG_ERR`, which are clearly wrong.