### PR TITLE
FreeBSD needs pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ else()
         )
 
     if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-        set(EXTRA_LIBS kvm)
+        set(EXTRA_LIBS kvm pthread)
     else()
         set(EXTRA_LIBS pthread rt dl)
     endif()


### PR DESCRIPTION
FreeBSD needs the pthread linker flag.