### PR TITLE
Fix compilation with Clang 3.5

### DIFF
--- a/src/crypto/cn_gpu_avx.cpp
+++ b/src/crypto/cn_gpu_avx.cpp
@@ -30,6 +30,12 @@
 #   include <intrin.h>
 #   define __restrict__ __restrict
 #endif
+#ifndef _mm256_bslli_epi128
+	#define _mm256_bslli_epi128(a, count) _mm256_slli_si256((a), (count))
+#endif
+#ifndef _mm256_bsrli_epi128
+	#define _mm256_bsrli_epi128(a, count) _mm256_srli_si256((a), (count))
+#endif
 
 inline void prep_dv_avx(__m256i* idx, __m256i& v, __m256& n01)
 {


### PR DESCRIPTION
Fix compilation with Clang 3.5 for those with limited compiler choices
Performance similar to gcc7+ on systems where gcc4 is the only alternative

Based on [official LLVM upstream patch](http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150518/129343.html) that was merged sometime after 3.5.0