### PR TITLE
updates image used in readme for new pool url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Originally based on cpuminer-multi with heavy optimizations/rewrites and removin
 * This is the **CPU-mining** version, there is also a [NVIDIA GPU version](https://github.com/xmrig/xmrig-nvidia) and [AMD GPU version]( https://github.com/xmrig/xmrig-amd).
 * [Roadmap](https://github.com/xmrig/xmrig/issues/106) for next releases.
 
-<img src="http://i.imgur.com/OKZRVDh.png" width="619" >
+<img src="http://i.imgur.com/Ymumes5.png" width="619" >
 
 #### Table of contents
 * [Features](#features)


### PR DESCRIPTION
minemonero.pro is deprecated, added new image for hashvault.pro on readme

https://imgur.com/a/b4pPCVc