### PR TITLE
Config: fix std::max issue with msvc2017

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -22,6 +22,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <string.h>
 #include <uv.h>
 #include <inttypes.h>


### PR DESCRIPTION
to fix the following errors:

    xmrig\src\core\Config.cpp(165): error C2065: 'max': undeclared identifier
    xmrig\src\core\Config.cpp(165): error C2275: 'size_t': illegal use of this type as an expression