### PR TITLE
Repair compilation with Clang 9.0.0

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -10,6 +10,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(/DNDEBUG)
 endif()
 
+include(CheckSymbolExists)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-strict-aliasing")
@@ -27,6 +29,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
     else()
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
+
+        add_definitions(/DHAVE_ROTR)
     endif()
 
     if (WIN32)
@@ -50,6 +54,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
     add_definitions(/D_CRT_SECURE_NO_WARNINGS)
     add_definitions(/D_CRT_NONSTDC_NO_WARNINGS)
     add_definitions(/DNOMINMAX)
+    add_definitions(/DHAVE_ROTR)
 
 elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
 
@@ -68,6 +73,11 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
     else()
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
+
+        check_symbol_exists("_rotr" "x86intrin.h" HAVE_ROTR)
+        if (HAVE_ROTR)
+            add_definitions(/DHAVE_ROTR)
+        endif()
     endif()
 
 endif()

--- a/src/crypto/soft_aes.h
+++ b/src/crypto/soft_aes.h
@@ -130,7 +130,7 @@ static inline uint32_t sub_word(uint32_t key)
          saes_sbox[key & 0xff];
 }
 
-#if (defined(__clang__) && __clang_major__ != 9) || defined(XMRIG_ARM)
+#ifndef HAVE_ROTR
 static inline uint32_t _rotr(uint32_t value, uint32_t amount)
 {
     return (value >> amount) | (value << ((32 - amount) & 31));

--- a/src/crypto/soft_aes.h
+++ b/src/crypto/soft_aes.h
@@ -130,7 +130,7 @@ static inline uint32_t sub_word(uint32_t key)
          saes_sbox[key & 0xff];
 }
 
-#if defined(__clang__) || defined(XMRIG_ARM)
+#if (defined(__clang__) && __clang_major__ != 9) || defined(XMRIG_ARM)
 static inline uint32_t _rotr(uint32_t value, uint32_t amount)
 {
     return (value >> amount) | (value << ((32 - amount) & 31));


### PR DESCRIPTION
which now includes its own _rotr intrinsic, so the fill-in collided with some already-defined errors.