### PR TITLE
evo branch: Repair colors on Windows (don't test uv_tty_init() return value)

### DIFF
--- a/src/base/io/log/backends/ConsoleLog.cpp
+++ b/src/base/io/log/backends/ConsoleLog.cpp
@@ -41,10 +41,15 @@ xmrig::ConsoleLog::ConsoleLog()
 
     m_tty = new uv_tty_t;
 
+#   ifdef WIN32
+    // Windows returns negative numbers even on success, so avoid testing return value
+    uv_tty_init(uv_default_loop(), m_tty, 1, 0);
+#   else
     if (uv_tty_init(uv_default_loop(), m_tty, 1, 0) < 0) {
         Log::colors = false;
         return;
     }
+#   endif
 
     uv_tty_set_mode(m_tty, UV_TTY_MODE_NORMAL);
 


### PR DESCRIPTION
uv_tty_init() returns negative even on success with Windows
This patch fixes color, tested on Win7 / cmd.exe shell (nothing special)
Does not change anything on Unix etc.

Someone plz test on Win10 and/or PowerShell and whatever other Windows console environments.