### PR TITLE
Fix compilation against older hwloc (tested Debian Jessie 1.10.0-3)

### DIFF
--- a/src/backend/cpu/platform/HwlocCpuInfo.h
+++ b/src/backend/cpu/platform/HwlocCpuInfo.h
@@ -29,6 +29,15 @@
 #include "backend/cpu/platform/BasicCpuInfo.h"
 
 
+// handle older hwloc where objects had other names
+#ifndef HWLOC_OBJ_PACKAGE
+#   define HWLOC_OBJ_PACKAGE HWLOC_OBJ_SOCKET
+#endif
+#ifndef HWLOC_OBJ_NUMANODE
+#   define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
+#endif
+
+
 typedef struct hwloc_obj *hwloc_obj_t;
 typedef struct hwloc_topology *hwloc_topology_t;
 


### PR DESCRIPTION
Some object types changed define-names, and otherwise seem to work the same.  Leave actual code properly 1.11.x+ compatible while simply copying through the defines when the new names don't exist (assume old hwloc, or crash anyway).

Works well on dual CPU Xeon system.