### PR TITLE
Build hwloc version string based on HWLOC_API_VERSION

### DIFF
--- a/src/backend/cpu/platform/HwlocCpuInfo.cpp
+++ b/src/backend/cpu/platform/HwlocCpuInfo.cpp
@@ -167,7 +167,11 @@ xmrig::HwlocCpuInfo::HwlocCpuInfo() : BasicCpuInfo(),
     else
 #   endif
     {
-        snprintf(m_backend, sizeof m_backend, "hwloc");
+        snprintf(m_backend, sizeof m_backend, "hwloc/%d.%d.%d",
+                       (HWLOC_API_VERSION>>16)&0x000000ff,
+                       (HWLOC_API_VERSION>>8 )&0x000000ff,
+                       (HWLOC_API_VERSION    )&0x000000ff
+               );
     }
 
     findCache(root, 2, 3, [this](hwloc_obj_t found) { this->m_cache[found->attr->cache.depth] += found->attr->cache.size; });


### PR DESCRIPTION
Build hwloc version string based on HWLOC_API_VERSION, whenever `hwlocVersion` object does not exist (<1.11.x)

Probably could just use this method on all versions, as it is more important to display the compiled lib/header version, than whatever the XML tree says its version is (which could be different?).  Maybe complain if they mismatch?