### PR TITLE
Fixed race condition in RandomX thread init

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -90,6 +90,8 @@ void xmrig::CpuWorker<N>::allocateRandomX_VM()
         if (Nonce::sequence(Nonce::CPU) == 0) {
             return;
         }
+
+        dataset = Rx::dataset(m_job.currentJob(), m_node);
     }
 
     if (!m_vm) {


### PR DESCRIPTION
Thread could deadlock if it started before dataset struct was allocated.
Thanks to crCr62U0 for reporting this.