### PR TITLE
Fix linker marking entire executable as having an executable stack

### DIFF
--- a/src/crypto/cn/asm/CryptonightR_template.S
+++ b/src/crypto/cn/asm/CryptonightR_template.S
@@ -1593,3 +1593,7 @@ FN_PREFIX(CryptonightR_instruction_mov254):
 FN_PREFIX(CryptonightR_instruction_mov255):
 
 FN_PREFIX(CryptonightR_instruction_mov256):
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/crypto/cn/asm/cn_main_loop.S
+++ b/src/crypto/cn/asm/cn_main_loop.S
@@ -71,3 +71,7 @@ FN_PREFIX(cnv2_rwz_double_mainloop_asm):
 	add rsp, 48
 	ret 0
 	mov eax, 3735929054
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/crypto/cn/asm/win64/cn_main_loop.S
+++ b/src/crypto/cn/asm/win64/cn_main_loop.S
@@ -43,3 +43,7 @@ cnv2_rwz_double_mainloop_asm:
 	#include "cn2/cnv2_rwz_double_main_loop.inc"
 	ret 0
 	mov eax, 3735929054
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/crypto/randomx/jit_compiler_x86_static.S
+++ b/src/crypto/randomx/jit_compiler_x86_static.S
@@ -206,3 +206,7 @@ DECL(randomx_reciprocal_fast):
 	mov rcx, rdi
 #endif
 	#include "asm/randomx_reciprocal.inc"
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
See: https://wiki.ubuntu.com/SecurityTeam/Roadmap/ExecutableStacks
See: https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart