### PR TITLE
Workaround for a bug in binutils-2.32-1 on ARM

### DIFF
--- a/src/crypto/randomx/jit_compiler_a64_static.S
+++ b/src/crypto/randomx/jit_compiler_a64_static.S
@@ -485,12 +485,13 @@ randomx_calc_dataset_item_aarch64:
 	stp	x10, x11, [sp, 80]
 	stp	x12, x13, [sp, 96]
 
+	ldr	x12, superscalarMul0
+
 	mov	x8, x0
 	mov	x9, x1
 	mov	x10, x2
 
 	# rl[0] = (itemNumber + 1) * superscalarMul0;
-	ldr	x12, superscalarMul0
 	madd	x0, x2, x12, x12
 
 	# rl[1] = rl[0] ^ superscalarAdd1;

--- a/src/crypto/randomx/virtual_machine.hpp
+++ b/src/crypto/randomx/virtual_machine.hpp
@@ -64,7 +64,7 @@ protected:
 	alignas(64) randomx::RegisterFile reg;
 	alignas(16) randomx::ProgramConfiguration config;
 	randomx::MemoryRegisters mem;
-	uint8_t* scratchpad;
+	uint8_t* scratchpad = nullptr;
 	union {
 		randomx_cache* cachePtr = nullptr;
 		randomx_dataset* datasetPtr;


### PR DESCRIPTION
ldr/madd instruction sequence makes compiled binary crash (linker replaces madd with random jump instruction), so separate them.