### PR TITLE
Add missing newline in help output

### DIFF
--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -60,7 +60,7 @@ Options:\n\
                                   rx/wow, rx/loki\n"
 #endif
 "\
-      --coin=COIN               specify coin instead of algorithm\
+      --coin=COIN               specify coin instead of algorithm\n\
   -o, --url=URL                 URL of mining server\n\
   -O, --userpass=U:P            username:password pair for mining server\n\
   -u, --user=USERNAME           username for mining server\n\


### PR DESCRIPTION
Help output is missing a newline