### PR TITLE
Fixes OclDevice::globalMemSize() that sometimes returns 0

### DIFF
--- a/src/backend/opencl/wrappers/OclDevice.cpp
+++ b/src/backend/opencl/wrappers/OclDevice.cpp
@@ -132,6 +132,8 @@ xmrig::OclDevice::OclDevice(uint32_t index, cl_device_id id, cl_platform_id plat
     m_board(OclLib::getString(id, 0x4038 /* CL_DEVICE_BOARD_NAME_AMD */)),
     m_name(OclLib::getString(id, CL_DEVICE_NAME)),
     m_vendor(OclLib::getString(id, CL_DEVICE_VENDOR)),
+    m_maxMemoryAlloc(OclLib::getUlong(id, CL_DEVICE_MAX_MEM_ALLOC_SIZE)),
+    m_globalMemory(OclLib::getUlong(id, CL_DEVICE_GLOBAL_MEM_SIZE)),
     m_computeUnits(OclLib::getUint(id, CL_DEVICE_MAX_COMPUTE_UNITS, 1)),
     m_index(index)
 {
@@ -152,24 +154,6 @@ xmrig::OclDevice::OclDevice(uint32_t index, cl_device_id id, cl_platform_id plat
             m_topology = PciTopology(bus, (slot >> 3) & 0xff, slot & 7);
         }
     }
-}
-
-
-size_t xmrig::OclDevice::freeMemSize() const
-{
-    return std::min(maxMemAllocSize(), globalMemSize());
-}
-
-
-size_t xmrig::OclDevice::globalMemSize() const
-{
-    return OclLib::getUlong(id(), CL_DEVICE_GLOBAL_MEM_SIZE);
-}
-
-
-size_t xmrig::OclDevice::maxMemAllocSize() const
-{
-    return OclLib::getUlong(id(), CL_DEVICE_MAX_MEM_ALLOC_SIZE);
 }
 
 

--- a/src/backend/opencl/wrappers/OclDevice.h
+++ b/src/backend/opencl/wrappers/OclDevice.h
@@ -76,7 +76,7 @@ public:
     inline OclVendor vendorId() const           { return m_vendorId; }
     inline Type type() const                    { return m_type; }
     inline uint32_t computeUnits() const        { return m_computeUnits; }
-    inline size_t freeMemSize() const           { return std::min(m_maxMemoryAlloc, m_globalMemory); }
+    inline size_t freeMemSize() const           { return std::min(maxMemAllocSize(), globalMemSize()); }
     inline size_t globalMemSize() const         { return m_globalMemory; }
     inline size_t maxMemAllocSize() const       { return m_maxMemoryAlloc; }
     inline uint32_t index() const               { return m_index; }

--- a/src/backend/opencl/wrappers/OclDevice.h
+++ b/src/backend/opencl/wrappers/OclDevice.h
@@ -33,6 +33,7 @@
 #include "backend/opencl/wrappers/OclVendor.h"
 #include "base/tools/String.h"
 
+#include <algorithm>
 
 using cl_device_id      = struct _cl_device_id *;
 using cl_platform_id    = struct _cl_platform_id *;
@@ -62,9 +63,6 @@ public:
     OclDevice() = delete;
     OclDevice(uint32_t index, cl_device_id id, cl_platform_id platform);
 
-    size_t freeMemSize() const;
-    size_t globalMemSize() const;
-    size_t maxMemAllocSize() const;
     String printableName() const;
     uint32_t clock() const;
     void generate(const Algorithm &algorithm, OclThreads &threads) const;
@@ -78,6 +76,9 @@ public:
     inline OclVendor vendorId() const           { return m_vendorId; }
     inline Type type() const                    { return m_type; }
     inline uint32_t computeUnits() const        { return m_computeUnits; }
+    inline size_t freeMemSize() const           { return std::min(m_maxMemoryAlloc, m_globalMemory); }
+    inline size_t globalMemSize() const         { return m_globalMemory; }
+    inline size_t maxMemAllocSize() const       { return m_maxMemoryAlloc; }
     inline uint32_t index() const               { return m_index; }
 
 #   ifdef XMRIG_FEATURE_API
@@ -90,6 +91,9 @@ private:
     const String m_board;
     const String m_name;
     const String m_vendor;
+    const size_t m_freeMemory       = 0;
+    const size_t m_maxMemoryAlloc   = 0;
+    const size_t m_globalMemory     = 0;
     const uint32_t m_computeUnits   = 1;
     const uint32_t m_index          = 0;
     OclVendor m_vendorId            = OCL_VENDOR_UNKNOWN;


### PR DESCRIPTION
This fixes random return of 0(zero) of globalMemSize() described in this issue https://github.com/xmrig/xmrig/issues/1235