### PR TITLE
increase stratum send buffer size

### DIFF
--- a/src/base/net/stratum/Client.h
+++ b/src/base/net/stratum/Client.h
@@ -128,7 +128,7 @@ private:
 
     static inline Client *getClient(void *data) { return m_storage.get(data); }
 
-    char m_sendBuf[2048] = { 0 };
+    char m_sendBuf[4096] = { 0 };
     const char *m_agent;
     Dns *m_dns;
     RecvBuf<kInputBufferSize> m_recvBuf;


### PR DESCRIPTION
This is needed for block templates over self-select as a block template can be over 2048 bytes. [[ref](https://github.com/jtgrassie/monero-pool/issues/28)]
