### PR TITLE
Add vzeroupper for processors with AVX

### DIFF
--- a/src/crypto/randomx/jit_compiler_x86.cpp
+++ b/src/crypto/randomx/jit_compiler_x86.cpp
@@ -292,7 +292,7 @@ namespace randomx {
 
 		int32_t info[4];
 		cpuid(1, info);
-		hasAVX = (info[2] & (1 << 28)) != 0;
+		hasAVX = ((info[2] & (1 << 27)) != 0) && ((info[2] & (1 << 28)) != 0);
 
 		allocatedCode = (uint8_t*)allocExecutableMemory(CodeSize * 2);
 		// Shift code base address to improve caching - all threads will use different L2/L3 cache sets

--- a/src/crypto/randomx/jit_compiler_x86.hpp
+++ b/src/crypto/randomx/jit_compiler_x86.hpp
@@ -73,6 +73,7 @@ namespace randomx {
 		uint32_t vm_flags;
 
 		static bool BranchesWithin32B;
+		bool hasAVX;
 
 		static void applyTweaks();
 		void generateProgramPrologue(Program&, ProgramConfiguration&);

--- a/src/crypto/randomx/jit_compiler_x86_static.S
+++ b/src/crypto/randomx/jit_compiler_x86_static.S
@@ -94,6 +94,9 @@ DECL(randomx_program_prologue_first_load):
 	ror rdx, 32
 	and edx, RANDOMX_SCRATCHPAD_MASK
 	stmxcsr dword ptr [rsp-20]
+	nop
+	nop
+	nop
 	jmp DECL(randomx_program_loop_begin)
 
 .balign 64

--- a/src/crypto/randomx/jit_compiler_x86_static.asm
+++ b/src/crypto/randomx/jit_compiler_x86_static.asm
@@ -82,6 +82,9 @@ randomx_program_prologue_first_load PROC
 	ror rdx, 32
 	and edx, RANDOMX_SCRATCHPAD_MASK
 	stmxcsr dword ptr [rsp-20]
+	nop
+	nop
+	nop
 	jmp randomx_program_loop_begin
 randomx_program_prologue_first_load ENDP
 


### PR DESCRIPTION
To avoid false dependencies on upper 128 bits of YMM registers.