### PR TITLE
zlib needed on some macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ elseif (XMRIG_OS_APPLE)
         src/App_unix.cpp
         src/crypto/common/VirtualMemory_unix.cpp
         )
+    set(EXTRA_LIBS z)
 else()
     list(APPEND SOURCES_OS
         src/App_unix.cpp


### PR DESCRIPTION
Needed for (at least MacPorts based) macOs builds.