### PR TITLE
Fixed setThreadAffinity()

### DIFF
--- a/src/base/kernel/Platform_hwloc.cpp
+++ b/src/base/kernel/Platform_hwloc.cpp
@@ -30,6 +30,7 @@
 
 
 #include <hwloc.h>
+#include <thread>
 
 
 bool xmrig::Platform::setThreadAffinity(uint64_t cpu_id)
@@ -42,8 +43,11 @@ bool xmrig::Platform::setThreadAffinity(uint64_t cpu_id)
     }
 
     if (hwloc_set_cpubind(cpu->topology(), pu->cpuset, HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT) >= 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         return true;
     }
 
-    return hwloc_set_cpubind(cpu->topology(), pu->cpuset, HWLOC_CPUBIND_THREAD) >= 0;
+    const bool result = (hwloc_set_cpubind(cpu->topology(), pu->cpuset, HWLOC_CPUBIND_THREAD) >= 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return result;
 }

--- a/src/base/kernel/Platform_mac.cpp
+++ b/src/base/kernel/Platform_mac.cpp
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <sys/resource.h>
 #include <uv.h>
+#include <thread>
 
 
 #include "base/kernel/Platform.h"
@@ -67,7 +68,9 @@ bool xmrig::Platform::setThreadAffinity(uint64_t cpu_id)
     thread_affinity_policy_data_t policy = { static_cast<integer_t>(cpu_id) };
     mach_thread = pthread_mach_thread_np(pthread_self());
 
-    return thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1) == KERN_SUCCESS;
+    const bool result = (thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1) == KERN_SUCCESS);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return result;
 }
 #endif
 

--- a/src/base/kernel/Platform_unix.cpp
+++ b/src/base/kernel/Platform_unix.cpp
@@ -37,6 +37,7 @@
 #include <sys/resource.h>
 #include <unistd.h>
 #include <uv.h>
+#include <thread>
 
 
 #include "base/kernel/Platform.h"
@@ -92,10 +93,13 @@ bool xmrig::Platform::setThreadAffinity(uint64_t cpu_id)
     CPU_SET(cpu_id, &mn);
 
 #   ifndef __ANDROID__
-    return pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &mn) == 0;
+    const bool result = (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &mn) == 0);
 #   else
-    return sched_setaffinity(gettid(), sizeof(cpu_set_t), &mn) == 0;
+    const bool result = (sched_setaffinity(gettid(), sizeof(cpu_set_t), &mn) == 0);
 #   endif
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return result;
 }
 #endif
 

--- a/src/base/kernel/Platform_win.cpp
+++ b/src/base/kernel/Platform_win.cpp
@@ -98,7 +98,9 @@ bool xmrig::Platform::setThreadAffinity(uint64_t cpu_id)
         LOG_ERR("Unable to set affinity. Windows supports only affinity up to 63.");
     }
 
-    return SetThreadAffinityMask(GetCurrentThread(), 1ULL << cpu_id) != 0;
+    const bool result = (SetThreadAffinityMask(GetCurrentThread(), 1ULL << cpu_id) != 0);
+    Sleep(1);
+    return result;
 }
 #endif
 


### PR DESCRIPTION
Added 1 ms sleep to guarantee thread rescheduling to the correct CPU core before returning.