### PR TITLE
Fix OpenSSL static link when BUILD_STATIC=ON is provided

### DIFF
--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -10,6 +10,11 @@ if (WITH_TLS)
         set(OPENSSL_USE_STATIC_LIBS TRUE)
     endif()
 
+    if (BUILD_STATIC)
+        set(OPENSSL_USE_STATIC_LIBS TRUE)
+    endif()
+
+
     find_package(OpenSSL)
 
     if (OPENSSL_FOUND)


### PR DESCRIPTION
OpenSSL still links as shared library even if BUILD_STATIC=ON is provided.