### PR TITLE
Fix Windows include files cases

### DIFF
--- a/cmake/OpenSSL.cmake
+++ b/cmake/OpenSSL.cmake
@@ -5,7 +5,7 @@ if (WITH_TLS)
         set(OPENSSL_USE_STATIC_LIBS TRUE)
         set(OPENSSL_MSVC_STATIC_RT TRUE)
 
-        set(EXTRA_LIBS ${EXTRA_LIBS} Crypt32)
+        set(EXTRA_LIBS ${EXTRA_LIBS} crypt32)
     elseif (APPLE)
         set(OPENSSL_USE_STATIC_LIBS TRUE)
     endif()

--- a/src/backend/opencl/OclCache_win.cpp
+++ b/src/backend/opencl/OclCache_win.cpp
@@ -24,7 +24,7 @@
 
 
 #include <direct.h>
-#include <Shlobj.h>
+#include <shlobj.h>
 #include <windows.h>
 
 

--- a/src/crypto/rx/Rx_win.cpp
+++ b/src/crypto/rx/Rx_win.cpp
@@ -36,7 +36,7 @@
 #include "crypto/rx/RxConfig.h"
 
 
-#include <Windows.h>
+#include <windows.h>
 #include <array>
 #include <string>
 #include <thread>


### PR DESCRIPTION
When cross-compiling on case sensitive systems, such as Linux, there will be errors.
Change cases of Windows include files and link library.