### PR TITLE
Increased max blob size to support Haven offshore capability

### DIFF
--- a/src/base/net/stratum/Job.h
+++ b/src/base/net/stratum/Job.h
@@ -45,7 +45,8 @@ class Job
 public:
     // Max blob size is 84 (75 fixed + 9 variable), aligned to 96. https://github.com/xmrig/xmrig/issues/1 Thanks fireice-uk.
     // SECOR increase requirements for blob size: https://github.com/xmrig/xmrig/issues/913
-    static constexpr const size_t kMaxBlobSize = 128;
+    // Haven (XHV) offshore increases requirements by adding pricing_record struct (192 bytes) to block_header.
+    static constexpr const size_t kMaxBlobSize = 384;
     static constexpr const size_t kMaxSeedSize = 32;
 
     Job() = default;


### PR DESCRIPTION
Haven offshore now requires a **pricing_record** struct (size 192 bytes) to be present in the block_header. Therefore the blob size for a block_header has increased significantly.

This pull request increases the max supported blob size to 384 bytes - the first multiple of 96 above the required size for Haven offshore.