### PR TITLE
RandomX: added parameter for scratchpad prefetch mode

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -21,7 +21,8 @@
         "rdmsr": true,
         "wrmsr": true,
         "cache_qos": false,
-        "numa": true
+        "numa": true,
+        "scratchpad_prefetch_mode": 1
     },
     "cpu": {
         "enabled": true,

--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -51,7 +51,12 @@ R"===(
     "randomx": {
         "init": -1,
         "mode": "auto",
-        "numa": true
+        "1gb-pages": false,
+        "rdmsr": true,
+        "wrmsr": true,
+        "cache_qos": false,
+        "numa": true,
+        "scratchpad_prefetch_mode": 1
     },
     "cpu": {
         "enabled": true,

--- a/src/crypto/randomx/randomx.h
+++ b/src/crypto/randomx/randomx.h
@@ -200,6 +200,8 @@ void randomx_apply_config(const T& config)
 	RandomX_CurrentConfig.Apply();
 }
 
+void randomx_set_scratchpad_prefetch_mode(int mode);
+
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/src/crypto/rx/Rx.cpp
+++ b/src/crypto/rx/Rx.cpp
@@ -32,6 +32,7 @@
 #include "base/io/log/Log.h"
 #include "crypto/rx/RxConfig.h"
 #include "crypto/rx/RxQueue.h"
+#include "crypto/randomx/randomx.h"
 
 
 namespace xmrig {
@@ -98,6 +99,8 @@ bool xmrig::Rx::init(const T &seed, const RxConfig &config, const CpuConfig &cpu
 
         return true;
     }
+
+    randomx_set_scratchpad_prefetch_mode(config.scratchpadPrefetchMode());
 
     if (isReady(seed)) {
         return true;

--- a/src/crypto/rx/RxConfig.cpp
+++ b/src/crypto/rx/RxConfig.cpp
@@ -57,6 +57,8 @@ static const char *kCacheQoS    = "cache_qos";
 static const char *kNUMA        = "numa";
 #endif
 
+static const char *kScratchpadPrefetchMode = "scratchpad_prefetch_mode";
+
 static const std::array<const char *, RxConfig::ModeMax> modeNames = { "auto", "fast", "light" };
 
 
@@ -118,6 +120,11 @@ bool xmrig::RxConfig::read(const rapidjson::Value &value)
         }
 #       endif
 
+        const int mode = Json::getInt(value, kScratchpadPrefetchMode, static_cast<int>(m_scratchpadPrefetchMode));
+        if ((mode >= ScratchpadPrefetchOff) && (mode < ScratchpadPrefetchMax)) {
+            m_scratchpadPrefetchMode = static_cast<ScratchpadPrefetchMode>(mode);
+        }
+
         return true;
     }
 
@@ -170,6 +177,8 @@ rapidjson::Value xmrig::RxConfig::toJSON(rapidjson::Document &doc) const
         obj.AddMember(StringRef(kNUMA), m_numa, allocator);
     }
 #   endif
+
+    obj.AddMember(StringRef(kScratchpadPrefetchMode), static_cast<int>(m_scratchpadPrefetchMode), allocator);
 
     return obj;
 }

--- a/src/crypto/rx/RxConfig.h
+++ b/src/crypto/rx/RxConfig.h
@@ -50,6 +50,14 @@ public:
         ModeMax
     };
 
+    enum ScratchpadPrefetchMode : uint32_t {
+        ScratchpadPrefetchOff,
+        ScratchpadPrefetchT0,
+        ScratchpadPrefetchNTA,
+        ScratchpadPrefetchMov,
+        ScratchpadPrefetchMax,
+    };
+
     bool read(const rapidjson::Value &value);
     rapidjson::Value toJSON(rapidjson::Document &doc) const;
 
@@ -67,6 +75,8 @@ public:
     inline bool wrmsr() const           { return m_wrmsr; }
     inline bool cacheQoS() const        { return m_cacheQoS; }
     inline Mode mode() const            { return m_mode; }
+
+    inline ScratchpadPrefetchMode scratchpadPrefetchMode() const { return m_scratchpadPrefetchMode; }
 
 #   ifdef XMRIG_FEATURE_MSR
     const char *msrPresetName() const;
@@ -93,6 +103,8 @@ private:
     bool m_rdmsr        = true;
     int m_threads       = -1;
     Mode m_mode         = AutoMode;
+
+    ScratchpadPrefetchMode m_scratchpadPrefetchMode = ScratchpadPrefetchT0;
 
 #   ifdef XMRIG_FEATURE_HWLOC
     std::vector<uint32_t> m_nodeset;


### PR DESCRIPTION
`scratchpad_prefetch_mode` can have 4 values:

0: off
1: use `prefetcht0` instruction (default, same as previous XMRig versions)
2: use `prefetchnta` instruction (faster on Coffee Lake and a few other CPUs)
3: use `mov` instruction