### PR TITLE
reserve at most 1 bit for wrapping detection

### DIFF
--- a/src/backend/common/WorkerJob.h
+++ b/src/backend/common/WorkerJob.h
@@ -96,7 +96,7 @@ private:
         const size_t size = job.size();
         m_jobs[index()]   = job;
         m_rounds[index()] = 0;
-        m_nonce_mask[index()] = job.isNicehash() ? 0xFFFFFFULL : (nonceSize() == sizeof(uint64_t) ? (-1ull  >> (job.extraNonce().size() * 4 + 1)): 0xFFFFFFFFULL);
+        m_nonce_mask[index()] = job.nonceMask();
 
         m_jobs[index()].setBackend(backend);
 
@@ -152,7 +152,7 @@ inline void xmrig::WorkerJob<1>::save(const Job &job, uint32_t reserveCount, Non
     m_index           = job.index();
     m_jobs[index()]   = job;
     m_rounds[index()] = 0;
-    m_nonce_mask[index()] = job.isNicehash() ? 0xFFFFFFULL : (nonceSize() == sizeof(uint64_t) ? (-1ull  >> (job.extraNonce().size() * 4 + 1)): 0xFFFFFFFFULL);
+    m_nonce_mask[index()] = job.nonceMask();
 
     m_jobs[index()].setBackend(backend);
 

--- a/src/base/net/stratum/Job.h
+++ b/src/base/net/stratum/Job.h
@@ -82,6 +82,7 @@ public:
     inline uint32_t backend() const                     { return m_backend; }
     inline uint64_t diff() const                        { return m_diff; }
     inline uint64_t height() const                      { return m_height; }
+    inline uint64_t nonceMask() const                   { return isNicehash() ? 0xFFFFFFULL : (nonceSize() == sizeof(uint64_t) ? (-1ull  >> (extraNonce().size() * 4)): 0xFFFFFFFFULL); }
     inline uint64_t target() const                      { return m_target; }
     inline uint8_t *blob()                              { return m_blob; }
     inline uint8_t fixedByte() const                    { return *(m_blob + 42); }

--- a/src/crypto/common/Nonce.cpp
+++ b/src/crypto/common/Nonce.cpp
@@ -52,6 +52,7 @@ xmrig::Nonce::Nonce()
 
 bool xmrig::Nonce::next(uint8_t index, uint32_t *nonce, uint32_t reserveCount, uint64_t mask)
 {
+    mask &= 0x7FFFFFFFFFFFFFFFULL;
     if (reserveCount == 0 || mask < reserveCount - 1) {
         return false;
     }
@@ -60,7 +61,8 @@ bool xmrig::Nonce::next(uint8_t index, uint32_t *nonce, uint32_t reserveCount, u
     while (true) {
         if (mask < counter) {
             return false;
-        } else if (mask - counter <= reserveCount - 1) {
+        }
+        else if (mask - counter <= reserveCount - 1) {
             pause(true);
             if (mask - counter < reserveCount - 1) {
                 return false;
@@ -72,7 +74,7 @@ bool xmrig::Nonce::next(uint8_t index, uint32_t *nonce, uint32_t reserveCount, u
         }
         *nonce = (nonce[0] & ~mask) | counter;
         if (mask > 0xFFFFFFFFULL) {
-            nonce[1] = (nonce[1] & (~mask >> 32)) | (counter  >> 32);
+            nonce[1] = (nonce[1] & (~mask >> 32)) | (counter >> 32);
         }
         return true;
     }


### PR DESCRIPTION
Add Job::nonceMask() to know mutable bits
Reserve at most 1 bit within Nonce::next to detect counter wrapping