### PR TITLE
RandomX improved performance of GCC compiled binaries

### DIFF
--- a/src/base/tools/Profiler.cpp
+++ b/src/base/tools/Profiler.cpp
@@ -20,6 +20,7 @@
 #include "base/tools/Profiler.h"
 #include "base/io/log/Log.h"
 #include "base/io/log/Tags.h"
+#include <cstring>
 #include <sstream>
 #include <thread>
 #include <chrono>

--- a/src/base/tools/Profiler.h
+++ b/src/base/tools/Profiler.h
@@ -37,6 +37,7 @@
 
 
 #include <cstdint>
+#include <cstddef>
 #include <type_traits>
 
 #if defined(_MSC_VER)

--- a/src/crypto/randomx/jit_compiler_x86.hpp
+++ b/src/crypto/randomx/jit_compiler_x86.hpp
@@ -41,7 +41,7 @@ namespace randomx {
 	class JitCompilerX86;
 	class Instruction;
 
-	typedef void(JitCompilerX86::*InstructionGeneratorX86)(const Instruction&);
+	typedef void(*InstructionGeneratorX86)(JitCompilerX86*, const Instruction&);
 
 	constexpr uint32_t CodeSize = 64 * 1024;
 

--- a/src/crypto/randomx/randomx.cpp
+++ b/src/crypto/randomx/randomx.cpp
@@ -267,7 +267,12 @@ void RandomX_ConfigurationBase::Apply()
 		}
 	}
 
-#define JIT_HANDLE(x, prev) randomx::JitCompilerX86::engine[k] = &randomx::JitCompilerX86::h_##x
+typedef void(randomx::JitCompilerX86::* InstructionGeneratorX86_2)(const randomx::Instruction&);
+
+#define JIT_HANDLE(x, prev) do { \
+		const InstructionGeneratorX86_2 p = &randomx::JitCompilerX86::h_##x; \
+		memcpy(randomx::JitCompilerX86::engine + k, &p, sizeof(p)); \
+	} while (0)
 
 #elif defined(XMRIG_ARMv8)
 


### PR DESCRIPTION
JIT compilator was slower compared to MSVC compiled binary. Up to +0.1% speedup on rx/wow in Linux.