### PR TITLE
Fix ARM build - Blake2 without SSE

### DIFF
--- a/cmake/randomx.cmake
+++ b/cmake/randomx.cmake
@@ -65,7 +65,7 @@ if (WITH_RANDOMX)
         set_property(SOURCE src/crypto/randomx/jit_compiler_a64_static.S PROPERTY LANGUAGE C)
     endif()
 
-    if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang)
+    if (NOT ARM_TARGET AND (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang))
         set_source_files_properties(src/crypto/randomx/blake2/blake2b_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
     endif()
 


### PR DESCRIPTION
Fixes #1844 by not using `-msse4.1` on Blake2 when target arch is ARM.