### PR TITLE
Fix ARM build - Blake2 without SSE, WITH_SSE cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(WITH_ADL             "Enable ADL (AMD Display Library) or sysfs support (
 option(WITH_STRICT_CACHE    "Enable strict checks for OpenCL cache" ON)
 option(WITH_INTERLEAVE_DEBUG_LOG "Enable debug log for threads interleave" OFF)
 option(WITH_PROFILING       "Enable profiling for developers" OFF)
+option(WITH_SSE             "Enable SSE for Blake2" ON)
 
 option(BUILD_STATIC         "Build static binary" OFF)
 option(ARM_TARGET           "Force use specific ARM target 8 or 7" 0)

--- a/cmake/randomx.cmake
+++ b/cmake/randomx.cmake
@@ -65,7 +65,7 @@ if (WITH_RANDOMX)
         set_property(SOURCE src/crypto/randomx/jit_compiler_a64_static.S PROPERTY LANGUAGE C)
     endif()
 
-    if (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang)
+    if (NOT ARM_TARGET AND WITH_SSE AND (CMAKE_C_COMPILER_ID MATCHES GNU OR CMAKE_C_COMPILER_ID MATCHES Clang))
         set_source_files_properties(src/crypto/randomx/blake2/blake2b_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
     endif()
 

--- a/doc/build/CMAKE_OPTIONS.md
+++ b/doc/build/CMAKE_OPTIONS.md
@@ -22,6 +22,7 @@ This feature add external dependency to libhwloc (1.10.0+) (except MSVC builds).
 * **`-DWITH_EMBEDDED_CONFIG=ON`** Enable [embedded](https://github.com/xmrig/xmrig/issues/957) config support.
 * **`-DWITH_OPENCL=OFF`** Disable OpenCL backend.
 * **`-DWITH_CUDA=OFF`** Disable CUDA backend.
+* **`-DWITH_SSE=OFF`** Disable SSE for Blake2 (useful for arm builds).
 
 ## Debug options
 


### PR DESCRIPTION
- Fixes #1844 by not using -msse4.1 on Blake2 when the target arch is ARM.
- `WITH_SSE` Cmake option added, one can disable SSE individually
- Same as #1860, just with a new `WITH_SSE` option. Pick one PR and close the other I guess :) (or whatever)