### PR TITLE
RandomX: allocate 2 MB pages for generated code, if possible

### DIFF
--- a/src/crypto/common/VirtualMemory_unix.cpp
+++ b/src/crypto/common/VirtualMemory_unix.cpp
@@ -68,7 +68,20 @@ void *xmrig::VirtualMemory::allocateExecutableMemory(size_t size)
 #   if defined(__APPLE__)
     void *mem = mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANON, -1, 0);
 #   else
-    void *mem = mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+#   if defined(MAP_HUGE_2MB)
+    constexpr int flag_2mb = MAP_HUGE_2MB;
+#   elif defined(MAP_HUGE_SHIFT)
+    constexpr int flag_2mb = (21 << MAP_HUGE_SHIFT);
+#   else
+    constexpr int flag_2mb = 0;
+#   endif
+
+    void *mem = mmap(0, align(size), PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE | flag_2mb, -1, 0);
+    if (!mem) {
+        void *mem = mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    }
+
 #   endif
 
     return mem == MAP_FAILED ? nullptr : mem;

--- a/src/crypto/common/VirtualMemory_win.cpp
+++ b/src/crypto/common/VirtualMemory_win.cpp
@@ -164,7 +164,13 @@ bool xmrig::VirtualMemory::isOneGbPagesAvailable()
 
 void *xmrig::VirtualMemory::allocateExecutableMemory(size_t size)
 {
-    return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    void* result = VirtualAlloc(nullptr, align(size), MEM_COMMIT | MEM_RESERVE | MEM_LARGE_PAGES, PAGE_EXECUTE_READWRITE);
+
+    if (!result) {
+        result = VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    }
+
+    return result;
 }
 
 

--- a/src/crypto/rx/RxVm.cpp
+++ b/src/crypto/rx/RxVm.cpp
@@ -64,7 +64,7 @@ randomx_vm* xmrig::RxVm::create(RxDataset *dataset, uint8_t *scratchpad, bool so
     rx_blake2b_use_sse41 = Cpu::info()->has(ICpuInfo::FLAG_SSE41) ? 1 : 0;
 #   endif
 
-    return randomx_create_vm(static_cast<randomx_flags>(flags), !dataset()->get() ? dataset->cache()->get() : nullptr, dataset->get(), scratchpad, node);
+    return randomx_create_vm(static_cast<randomx_flags>(flags), !dataset->get() ? dataset->cache()->get() : nullptr, dataset->get(), scratchpad, node);
 }
 
 


### PR DESCRIPTION
+0.2% boost on Ryzen 7 3700X