### PR TITLE
RandomX: align args

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -215,7 +215,7 @@ void xmrig::CpuWorker<N>::start()
 
 #       ifdef XMRIG_ALGO_RANDOMX
         bool first = true;
-        uint64_t tempHash[8] = {};
+        alignas(16) uint64_t tempHash[8] = {};
 
         // RandomX is faster, we don't need to store stats so often
         if (m_job.currentJob().algorithm().family() == Algorithm::RANDOM_X) {

--- a/src/backend/cpu/CpuWorker.h
+++ b/src/backend/cpu/CpuWorker.h
@@ -82,7 +82,7 @@ private:
     const int m_astrobwtMaxSize;
     const Miner *m_miner;
     cryptonight_ctx *m_ctx[N];
-    uint8_t m_hash[N * 32]{ 0 };
+    alignas(16) uint8_t m_hash[N * 32]{ 0 };
     VirtualMemory *m_memory = nullptr;
     WorkerJob<N> m_job;
 

--- a/src/crypto/randomx/aes_hash.cpp
+++ b/src/crypto/randomx/aes_hash.cpp
@@ -387,8 +387,8 @@ void SelectSoftAESImpl(size_t threadsCount)
       for (size_t t = 0; t < threadsCount; ++t) {
         threads.emplace_back([&, t]() {
           std::vector<uint8_t> scratchpad(10 * 1024);
-          uint8_t hash[64] = {};
-          uint8_t state[64] = {};
+          alignas(16) uint8_t hash[64] = {};
+          alignas(16) uint8_t state[64] = {};
           do {
           (*impl[i])(scratchpad.data(), scratchpad.size(), hash, state);
           ++count[t];

--- a/src/net/JobResults.cpp
+++ b/src/net/JobResults.cpp
@@ -114,7 +114,7 @@ static void getResults(JobBundle &bundle, std::vector<JobResult> &results, uint3
 {
     const auto &algorithm = bundle.job.algorithm();
     auto memory           = new VirtualMemory(algorithm.l3(), false, false, false);
-    uint8_t hash[32]{ 0 };
+    alignas(16) uint8_t hash[32]{ 0 };
 
     if (algorithm.family() == Algorithm::RANDOM_X) {
 #       ifdef XMRIG_ALGO_RANDOMX


### PR DESCRIPTION
tempHash/output must be 16-byte aligned for randomx_calculate_hash{,_first,_next}