### PR TITLE
RandomX: remove duplicate SuperscalarHash generation

### DIFF
--- a/src/crypto/randomx/dataset.hpp
+++ b/src/crypto/randomx/dataset.hpp
@@ -72,7 +72,6 @@ namespace randomx {
 	void deallocCache(randomx_cache* cache);
 
 	void initCache(randomx_cache*, const void*, size_t);
-	void initCacheCompile(randomx_cache*, const void*, size_t);
 	void initDatasetItem(randomx_cache* cache, uint8_t* out, uint64_t blockNumber);
 	void initDataset(randomx_cache* cache, uint8_t* dataset, uint32_t startBlock, uint32_t endBlock);
 }

--- a/src/crypto/randomx/randomx.cpp
+++ b/src/crypto/randomx/randomx.cpp
@@ -395,7 +395,7 @@ extern "C" {
 
 				case RANDOMX_FLAG_JIT:
 					cache->jit          = new randomx::JitCompiler();
-					cache->initialize   = &randomx::initCacheCompile;
+					cache->initialize   = &randomx::initCache;
 					cache->datasetInit  = cache->jit->getDatasetInitFunc();
 					cache->memory       = memory;
 					break;


### PR DESCRIPTION
SuperscalarHash generates twice in initCacheCompile. Fix it.