### PR TITLE
More precise hashrate calculation

### DIFF
--- a/src/backend/common/HashrateInterpolator.cpp
+++ b/src/backend/common/HashrateInterpolator.cpp
@@ -5,8 +5,8 @@
  * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018-2020 SChernykh   <https://github.com/SChernykh>
+ * Copyright 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -22,38 +22,44 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_IWORKER_H
-#define XMRIG_IWORKER_H
+
+#include "backend/common/HashrateInterpolator.h"
 
 
-#include <cstdint>
-#include <cstddef>
-
-
-namespace xmrig {
-
-
-class VirtualMemory;
-class Job;
-
-
-class IWorker
+uint64_t xmrig::HashrateInterpolator::interpolate(uint64_t timeStamp) const
 {
-public:
-    virtual ~IWorker() = default;
+    timeStamp -= LagMS;
 
-    virtual bool selfTest()                                   = 0;
-    virtual const VirtualMemory *memory() const               = 0;
-    virtual size_t id() const                                 = 0;
-    virtual size_t intensity() const                          = 0;
-    virtual uint64_t rawHashes() const                        = 0;
-    virtual void getHashrateData(uint64_t&, uint64_t&) const  = 0;
-    virtual void start()                                      = 0;
-    virtual void jobEarlyNotification(const Job&)             = 0;
-};
+    std::lock_guard<std::mutex> l(m_lock);
 
+    const size_t N = m_data.size();
 
-} // namespace xmrig
+    if (N < 2) {
+        return 0;
+    }
 
+    for (size_t i = 0; i < N - 1; ++i) {
+        const auto& a = m_data[i];
+        const auto& b = m_data[i + 1];
 
-#endif // XMRIG_IWORKER_H
+        if (a.second <= timeStamp && timeStamp <= b.second) {
+            return a.first + static_cast<int64_t>(b.first - a.first) * (timeStamp - a.second) / (b.second - a.second);
+        }
+    }
+
+    return 0;
+}
+
+void xmrig::HashrateInterpolator::addDataPoint(uint64_t count, uint64_t timeStamp)
+{
+    std::lock_guard<std::mutex> l(m_lock);
+
+    // Clean up old data
+    if (!m_data.empty()) {
+        while (timeStamp - m_data.front().second > LagMS * 2) {
+            m_data.pop_front();
+        }
+    }
+
+    m_data.emplace_back(count, timeStamp);
+}

--- a/src/backend/common/HashrateInterpolator.cpp
+++ b/src/backend/common/HashrateInterpolator.cpp
@@ -55,10 +55,8 @@ void xmrig::HashrateInterpolator::addDataPoint(uint64_t count, uint64_t timeStam
     std::lock_guard<std::mutex> l(m_lock);
 
     // Clean up old data
-    if (!m_data.empty()) {
-        while (timeStamp - m_data.front().second > LagMS * 2) {
-            m_data.pop_front();
-        }
+    while (!m_data.empty() && (timeStamp - m_data.front().second > LagMS * 2)) {
+        m_data.pop_front();
     }
 
     m_data.emplace_back(count, timeStamp);

--- a/src/backend/common/HashrateInterpolator.h
+++ b/src/backend/common/HashrateInterpolator.h
@@ -5,8 +5,8 @@
  * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
  * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
  * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright 2018-2020 SChernykh   <https://github.com/SChernykh>
+ * Copyright 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -22,38 +22,36 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_IWORKER_H
-#define XMRIG_IWORKER_H
+#ifndef XMRIG_HASHRATE_INTERPOLATOR_H
+#define XMRIG_HASHRATE_INTERPOLATOR_H
 
 
-#include <cstdint>
-#include <cstddef>
+#include <mutex>
+#include <deque>
+#include <utility>
 
 
 namespace xmrig {
 
 
-class VirtualMemory;
-class Job;
-
-
-class IWorker
+class HashrateInterpolator
 {
 public:
-    virtual ~IWorker() = default;
+    enum {
+        LagMS = 4000,
+    };
 
-    virtual bool selfTest()                                   = 0;
-    virtual const VirtualMemory *memory() const               = 0;
-    virtual size_t id() const                                 = 0;
-    virtual size_t intensity() const                          = 0;
-    virtual uint64_t rawHashes() const                        = 0;
-    virtual void getHashrateData(uint64_t&, uint64_t&) const  = 0;
-    virtual void start()                                      = 0;
-    virtual void jobEarlyNotification(const Job&)             = 0;
+    uint64_t interpolate(uint64_t timeStamp) const;
+    void addDataPoint(uint64_t count, uint64_t timeStamp);
+
+private:
+    // Buffer of hashrate counters, used for linear interpolation of past data
+    mutable std::mutex m_lock;
+    std::deque<std::pair<uint64_t, uint64_t>> m_data;
 };
 
 
 } // namespace xmrig
 
 
-#endif // XMRIG_IWORKER_H
+#endif /* XMRIG_HASHRATE_INTERPOLATOR_H */

--- a/src/backend/common/Worker.cpp
+++ b/src/backend/common/Worker.cpp
@@ -48,7 +48,7 @@ void xmrig::Worker::storeStats()
 
     // Fill in the data for that index
     m_hashCount[index] = m_count;
-    m_timestamp[index] = Chrono::highResolutionMSecs();
+    m_timestamp[index] = Chrono::steadyMSecs();
 
     // Switch to that index
     // All data will be in memory by the time it completes thanks to std::memory_order_seq_cst

--- a/src/backend/common/Worker.h
+++ b/src/backend/common/Worker.h
@@ -44,6 +44,7 @@ public:
 
     inline const VirtualMemory *memory() const override   { return nullptr; }
     inline size_t id() const override                     { return m_id; }
+    inline uint64_t rawHashes() const override            { return m_count; }
     void getHashrateData(uint64_t& hashCount, uint64_t& timeStamp) const override;
     inline void jobEarlyNotification(const Job&) override {}
 

--- a/src/backend/common/Workers.cpp
+++ b/src/backend/common/Workers.cpp
@@ -29,6 +29,7 @@
 #include "backend/common/Workers.h"
 #include "backend/cpu/CpuWorker.h"
 #include "base/io/log/Log.h"
+#include "base/tools/Chrono.h"
 #include "base/tools/Object.h"
 
 
@@ -142,12 +143,19 @@ void xmrig::Workers<T>::tick(uint64_t)
         return;
     }
 
+    uint64_t totalHashCount = 0;
+
     for (Thread<T> *handle : m_workers) {
         if (handle->worker()) {
             uint64_t hashCount, timeStamp;
             handle->worker()->getHashrateData(hashCount, timeStamp);
-            d_ptr->hashrate->add(handle->id(), hashCount, timeStamp);
+            d_ptr->hashrate->add(handle->id() + 1, hashCount, timeStamp);
+            totalHashCount += handle->worker()->rawHashes();
         }
+    }
+
+    if (totalHashCount > 0) {
+        d_ptr->hashrate->add(0, totalHashCount, Chrono::steadyMSecs());
     }
 }
 

--- a/src/backend/common/common.cmake
+++ b/src/backend/common/common.cmake
@@ -1,5 +1,6 @@
 set(HEADERS_BACKEND_COMMON
     src/backend/common/Hashrate.h
+    src/backend/common/HashrateInterpolator.h
     src/backend/common/Tags.h
     src/backend/common/interfaces/IBackend.h
     src/backend/common/interfaces/IRxListener.h
@@ -15,6 +16,7 @@ set(HEADERS_BACKEND_COMMON
 
 set(SOURCES_BACKEND_COMMON
     src/backend/common/Hashrate.cpp
+    src/backend/common/HashrateInterpolator.cpp
     src/backend/common/Threads.cpp
     src/backend/common/Worker.cpp
     src/backend/common/Workers.cpp

--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -304,9 +304,9 @@ void xmrig::CpuBackend::printHashrate(bool details)
          Log::print("| %8zu | %8" PRId64 " | %7s | %7s | %7s |",
                     i,
                     data.affinity,
-                    Hashrate::format(hashrate()->calc(i, Hashrate::ShortInterval),  num,         sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::MediumInterval), num + 8,     sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::LargeInterval),  num + 8 * 2, sizeof num / 3)
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::ShortInterval),  num,         sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::MediumInterval), num + 8,     sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::LargeInterval),  num + 8 * 2, sizeof num / 3)
                     );
 
          i++;

--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -218,9 +218,11 @@ void xmrig::CpuWorker<N>::start()
         alignas(16) uint64_t tempHash[8] = {};
 
         // RandomX is faster, we don't need to store stats so often
+#       ifndef XMRIG_ARM
         if (m_job.currentJob().algorithm().family() == Algorithm::RANDOM_X) {
             storeStatsMask = 63;
         }
+#       endif
 #       endif
 
         while (!Nonce::isOutdated(Nonce::CPU, m_job.sequence())) {

--- a/src/backend/cuda/CudaBackend.cpp
+++ b/src/backend/cuda/CudaBackend.cpp
@@ -409,9 +409,9 @@ void xmrig::CudaBackend::printHashrate(bool details)
          Log::print("| %8zu | %8" PRId64 " | %8s | %8s | %8s |" CYAN_BOLD(" #%u") YELLOW(" %s") GREEN(" %s"),
                     i,
                     data.thread.affinity(),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::MediumInterval) * scale, num + 16,      sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::MediumInterval) * scale, num + 16,      sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3),
                     data.device.index(),
                     data.device.topology().toString().data(),
                     data.device.name().data()
@@ -421,9 +421,9 @@ void xmrig::CudaBackend::printHashrate(bool details)
     }
 
     Log::print(WHITE_BOLD_S "|        - |        - | %8s | %8s | %8s |",
-               Hashrate::format(hashrate()->calc(Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
-               Hashrate::format(hashrate()->calc(Hashrate::MediumInterval) * scale, num + 16,     sizeof num / 3),
-               Hashrate::format(hashrate()->calc(Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3)
+               Hashrate::format(hashrate_short  * scale, num,          sizeof num / 3),
+               Hashrate::format(hashrate_medium * scale, num + 16,     sizeof num / 3),
+               Hashrate::format(hashrate_large  * scale, num + 16 * 2, sizeof num / 3)
                );
 }
 

--- a/src/backend/cuda/CudaWorker.cpp
+++ b/src/backend/cuda/CudaWorker.cpp
@@ -120,6 +120,12 @@ xmrig::CudaWorker::~CudaWorker()
 }
 
 
+uint64_t xmrig::CudaWorker::rawHashes() const
+{
+    return m_hashrateData.interpolate(Chrono::steadyMSecs());
+}
+
+
 void xmrig::CudaWorker::jobEarlyNotification(const Job& job)
 {
     if (m_runner) {
@@ -206,6 +212,9 @@ void xmrig::CudaWorker::storeStats()
     }
 
     m_count += m_runner ? m_runner->processedHashes() : 0;
+
+    const uint64_t timeStamp = Chrono::steadyMSecs();
+    m_hashrateData.addDataPoint(m_count, timeStamp);
 
     Worker::storeStats();
 }

--- a/src/backend/cuda/CudaWorker.h
+++ b/src/backend/cuda/CudaWorker.h
@@ -27,6 +27,7 @@
 #define XMRIG_CUDAWORKER_H
 
 
+#include "backend/common/HashrateInterpolator.h"
 #include "backend/common/Worker.h"
 #include "backend/common/WorkerJob.h"
 #include "backend/cuda/CudaLaunchData.h"
@@ -49,6 +50,7 @@ public:
 
     ~CudaWorker() override;
 
+    uint64_t rawHashes() const override;
     void jobEarlyNotification(const Job&) override;
 
     static std::atomic<bool> ready;
@@ -67,6 +69,8 @@ private:
     ICudaRunner *m_runner = nullptr;
     WorkerJob<1> m_job;
     uint32_t m_deviceIndex;
+
+    HashrateInterpolator m_hashrateData;
 };
 
 

--- a/src/backend/opencl/OclBackend.cpp
+++ b/src/backend/opencl/OclBackend.cpp
@@ -385,9 +385,9 @@ void xmrig::OclBackend::printHashrate(bool details)
          Log::print("| %8zu | %8" PRId64 " | %8s | %8s | %8s |" CYAN_BOLD(" #%u") YELLOW(" %s") " %s",
                     i,
                     data.affinity,
-                    Hashrate::format(hashrate()->calc(i, Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::MediumInterval) * scale, num + 16,     sizeof num / 3),
-                    Hashrate::format(hashrate()->calc(i, Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::MediumInterval) * scale, num + 16,     sizeof num / 3),
+                    Hashrate::format(hashrate()->calc(i + 1, Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3),
                     data.device.index(),
                     data.device.topology().toString().data(),
                     data.device.printableName().data()
@@ -397,9 +397,9 @@ void xmrig::OclBackend::printHashrate(bool details)
     }
 
     Log::print(WHITE_BOLD_S "|        - |        - | %8s | %8s | %8s |",
-               Hashrate::format(hashrate()->calc(Hashrate::ShortInterval)  * scale, num,          sizeof num / 3),
-               Hashrate::format(hashrate()->calc(Hashrate::MediumInterval) * scale, num + 16,     sizeof num / 3),
-               Hashrate::format(hashrate()->calc(Hashrate::LargeInterval)  * scale, num + 16 * 2, sizeof num / 3)
+               Hashrate::format(hashrate_short  * scale, num,          sizeof num / 3),
+               Hashrate::format(hashrate_medium * scale, num + 16,     sizeof num / 3),
+               Hashrate::format(hashrate_large  * scale, num + 16 * 2, sizeof num / 3)
                );
 }
 

--- a/src/backend/opencl/OclWorker.cpp
+++ b/src/backend/opencl/OclWorker.cpp
@@ -140,6 +140,12 @@ xmrig::OclWorker::~OclWorker()
 }
 
 
+uint64_t xmrig::OclWorker::rawHashes() const
+{
+    return m_hashrateData.interpolate(Chrono::steadyMSecs());
+}
+
+
 void xmrig::OclWorker::jobEarlyNotification(const Job& job)
 {
     if (m_runner) {
@@ -247,8 +253,11 @@ void xmrig::OclWorker::storeStats(uint64_t t)
     }
 
     m_count += m_runner->processedHashes();
+    const uint64_t timeStamp = Chrono::steadyMSecs();
 
-    m_sharedData.setRunTime(Chrono::steadyMSecs() - t);
+    m_hashrateData.addDataPoint(m_count, timeStamp);
+
+    m_sharedData.setRunTime(timeStamp - t);
 
     Worker::storeStats();
 }

--- a/src/backend/opencl/OclWorker.h
+++ b/src/backend/opencl/OclWorker.h
@@ -27,6 +27,7 @@
 #define XMRIG_OCLWORKER_H
 
 
+#include "backend/common/HashrateInterpolator.h"
 #include "backend/common/Worker.h"
 #include "backend/common/WorkerJob.h"
 #include "backend/opencl/OclLaunchData.h"
@@ -50,6 +51,7 @@ public:
 
     ~OclWorker() override;
 
+    uint64_t rawHashes() const override;
     void jobEarlyNotification(const Job&) override;
 
     static std::atomic<bool> ready;
@@ -70,6 +72,8 @@ private:
     OclSharedData &m_sharedData;
     WorkerJob<1> m_job;
     uint32_t m_deviceIndex;
+
+    HashrateInterpolator m_hashrateData;
 };
 
 

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -203,7 +203,7 @@ public:
                 continue;
             }
 
-            for (size_t i = 0; i < hr->threads(); i++) {
+            for (size_t i = 1; i < hr->threads(); i++) {
                 Value thread(kArrayType);
                 thread.PushBack(Hashrate::normalize(hr->calc(i, Hashrate::ShortInterval)),  allocator);
                 thread.PushBack(Hashrate::normalize(hr->calc(i, Hashrate::MediumInterval)), allocator);


### PR DESCRIPTION
- Use only steady timestamp counters to guarantee correctness
- CPU backend: directly measure total hashrate using raw hash counters from each thread; update data more often on ARM CPUs because they're slower
- GPU backends: directly measure total hashrate too, but use interpolator with 4 second lag to fix variance from batches of hashes

Total hashrate is now measured directly (realtime for CPU, 4 seconds lag for GPU), so it might differ a bit from the sum of all thread hashrates because data points are taken at different moments in time.

Overhead is reduced a lot since it doesn't have to go through all threads to calculate max total hashrate on every timer tick (2 times a second).