### PR TITLE
WorkerJob: fix calls of add/nextRound

### DIFF
--- a/src/backend/opencl/OclWorker.h
+++ b/src/backend/opencl/OclWorker.h
@@ -67,7 +67,6 @@ private:
 
     const Algorithm m_algorithm;
     const Miner *m_miner;
-    const uint32_t m_intensity;
     IOclRunner *m_runner = nullptr;
     OclSharedData &m_sharedData;
     WorkerJob<1> m_job;


### PR DESCRIPTION
WorkerJob::nextRound() doesn't require roundSize to be power of 2
Use CudaWorker::intensity(), OclWorker::intensity() to get device batch size
Sync nonce and device iteration