### PR TITLE
MSR: supress kernel module warning

### DIFF
--- a/src/crypto/rx/Rx_linux.cpp
+++ b/src/crypto/rx/Rx_linux.cpp
@@ -151,7 +151,7 @@ static bool wrmsr_on_all_cpus(uint32_t reg, uint64_t value, uint64_t mask, T&& c
 
 static bool wrmsr_modprobe()
 {
-    if (system("/sbin/modprobe msr > /dev/null 2>&1") != 0) {
+    if (system("/sbin/modprobe msr allow_writes=on > /dev/null 2>&1") != 0) {
         LOG_WARN(CLEAR "%s" YELLOW_BOLD_S "msr kernel module is not available", tag);
 
         return false;


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/a7e1f67ed29f0c339e2aa7483d13b085127566ab#diff-2f768554951616110618f5c2f6b3a580b570ca63a9bbbe6b3300adf66ee84443
Writes can still be allowed by supplying the `allow_writes=on` module parameter