### PR TITLE
Add checking for config files in user home directory

### DIFF
--- a/src/base/kernel/Base.cpp
+++ b/src/base/kernel/Base.cpp
@@ -136,6 +136,18 @@ private:
         if (read(chain, config)) {
             return config.release();
         }
+        
+        chain.addFile(Process::location(Process::HomeLocation, ".xmrig.json"));
+
+        if (read(chain, config)) {
+            return config.release();
+        }
+        
+        chain.addFile(Process::location(Process::HomeLocation, ".config/xmrig.json"));
+
+        if (read(chain, config)) {
+            return config.release();
+        }
 
 #       ifdef XMRIG_FEATURE_EMBEDDED_CONFIG
         chain.addRaw(default_config);


### PR DESCRIPTION
Check for configuration files in the home directory to give the user sane config locations without a command line argument. Especially useful for Linux packaging. Made to resolve #1923 