### PR TITLE
Add GitHub Actions compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,4 +100,4 @@ jobs:
         uses: actions/upload-artifact@v2.2.1
         with:
           name: xmrig-windows
-          path: ${{ github.workspace }}\build\xmrig.exe
+          path: ${{ github.workspace }}\build\Release\xmrig.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,4 +100,4 @@ jobs:
         uses: actions/upload-artifact@v2.2.1
         with:
           name: xmrig-windows
-          path: ${{ github.workspace }}/build/xmrig.exe
+          path: ${{ github.workspace }}\build\xmrig.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,103 @@
+name: Build XMRig
+
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: get dependencies
+        run: sudo apt-get install git build-essential cmake automake libtool autoconf
+      - name: use cache
+        uses: actions/cache@v2.1.3
+        id: cache
+        with:
+          path: scripts/deps
+          key: ${{ runner.os }}-${{ hashFiles('scripts/build**.sh') }}
+      - name: build dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir build && cd scripts
+          ./build_deps.sh
+      - name: build xmrig
+        run: |
+          if [ ! -d "build" ]; then
+            mkdir build
+          fi
+          cd build
+          cmake .. -DXMRIG_DEPS=scripts/deps
+          make -j2
+      - name: upload linux artifact
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: xmrig-linux
+          path: ${{ github.workspace }}/build/xmrig
+
+  build-osx:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: get dependencies
+        run: brew install cmake wget automake libtool autoconf
+      - name: use cache
+        uses: actions/cache@v2.1.3
+        id: cache
+        with:
+          path: scripts/deps
+          key: ${{ runner.os }}-${{ hashFiles('scripts/build**.sh') }}
+      - name: build dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir build && cd scripts
+          ./build_deps.sh
+      - name: build xmrig
+        run: |
+          if [ ! -d "build" ]; then
+            mkdir build
+          fi
+          cd build
+          cmake .. -DXMRIG_DEPS=scripts/deps
+          make -j2
+      - name: upload macos artifact
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: xmrig-osx
+          path: ${{ github.workspace }}/build/xmrig
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: check cache
+        id: deps
+        run: |
+          $head = Invoke-Expression 'git ls-remote https://github.com/xmrig/xmrig-deps | select -first 1'
+          Write-Host ::set-output name=id::($head.Split("`t"))[0]
+      - name: use cache
+        uses: actions/cache@v2.1.3
+        id: cache
+        with:
+          path: c:\xmrig-deps\
+          key: ${{ runner.os }}-${{ steps.deps.outputs.id }}
+      - name: get dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir c:\xmrig-deps
+          Invoke-WebRequest -Uri https://github.com/xmrig/xmrig-deps/archive/master.zip -OutFile master.zip
+          Expand-Archive -Path master.zip -DestinationPath c:\xmrig-deps\
+      - name: build
+        run: |
+          mkdir build
+          cd build
+          cmake .. -G "Visual Studio 16 2019" -A x64 -DXMRIG_DEPS=c:\xmrig-deps\xmrig-deps-master\msvc2019\x64
+          cmake --build . --config Release
+      - name: upload windows artifact
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: xmrig-windows
+          path: ${{ github.workspace }}/build/xmrig.exe

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Github All Releases](https://img.shields.io/github/downloads/xmrig/xmrig/total.svg)](https://github.com/xmrig/xmrig/releases)
 [![GitHub release](https://img.shields.io/github/release/xmrig/xmrig/all.svg)](https://github.com/xmrig/xmrig/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/releases)
-[![GitHub Actions](https://github.com/xmrig/xmrig/workflows/Build%20XMRig/badge.svg)](https://github.com/xmrig/xmrig/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/xmrig/xmrig/Build%20XMRig)](https://github.com/xmrig/xmrig/actions)
 [![GitHub license](https://img.shields.io/github/license/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/blob/master/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/network)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Github All Releases](https://img.shields.io/github/downloads/xmrig/xmrig/total.svg)](https://github.com/xmrig/xmrig/releases)
 [![GitHub release](https://img.shields.io/github/release/xmrig/xmrig/all.svg)](https://github.com/xmrig/xmrig/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/releases)
+[![GitHub Actions](https://github.com/xmrig/xmrig/workflows/Build%20XMRig/badge.svg)](https://github.com/xmrig/xmrig/actions)
 [![GitHub license](https://img.shields.io/github/license/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/blob/master/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/xmrig/xmrig.svg)](https://github.com/xmrig/xmrig/network)


### PR DESCRIPTION
This will automatically compile XMRig on Linux, MacOS, and Windows every time a commit is made and produce a (statically linked) build artifact by using GitHub Actions. Also adds a shiny new badge.
It also does this to pull requests, in addition to normal pushes.