### PR TITLE
Make single thread bench cheat-resistant

### DIFF
--- a/src/backend/common/Benchmark.cpp
+++ b/src/backend/common/Benchmark.cpp
@@ -69,6 +69,38 @@ static const std::map<int, std::map<uint32_t, uint64_t> > hashCheck = {
 };
 
 
+static const std::map<int, std::map<uint32_t, uint64_t> > hashCheck1T = {
+    { Algorithm::RX_0, {
+        {   250000U, 0x90A15B799486F3EBULL },
+        {   500000U, 0xAA83118FEE570F9AULL },
+        {  1000000U, 0x3DF47B0A427C93D9ULL },
+        {  2000000U, 0xED4D639B0AEB85C6ULL },
+        {  3000000U, 0x2D4F9B4275A713C3ULL },
+        {  4000000U, 0xA9EBE4888377F8D3ULL },
+        {  5000000U, 0xB92F81851E180454ULL },
+        {  6000000U, 0xFB9F98F63C2F1B7DULL },
+        {  7000000U, 0x2CC3D7A779D5AB35ULL },
+        {  8000000U, 0x2EEF833EA462F4B1ULL },
+        {  9000000U, 0xC6D39EF59213A07CULL },
+        { 10000000U, 0x95E6BAE68DD779CDULL }
+    }},
+    { Algorithm::RX_WOW, {
+        {   250000U, 0x7B409F096C863207ULL },
+        {   500000U, 0x70B7B80D15654216ULL },
+        {  1000000U, 0x31301CC550306A59ULL },
+        {  2000000U, 0x92F65E9E31116361ULL },
+        {  3000000U, 0x7FE8DF6F43BA5285ULL },
+        {  4000000U, 0xD6CDA54FE4D9BBF7ULL },
+        {  5000000U, 0x73AF673E1A38E2B4ULL },
+        {  6000000U, 0x81FDC5C4B45D84E4ULL },
+        {  7000000U, 0xAA08CA57666DC874ULL },
+        {  8000000U, 0x9DCEFB833FC875BCULL },
+        {  9000000U, 0x862F051352CFCA1FULL },
+        { 10000000U, 0xC403F220189E8430ULL }
+    }}
+};
+
+
 } // namespace xmrig
 
 
@@ -214,7 +246,8 @@ uint64_t xmrig::Benchmark::referenceHash() const
     uint64_t hash = 0;
 
     try {
-        hash = hashCheck.at(m_algo).at(m_end);
+        const auto& h = (m_workers == 1) ? hashCheck1T : hashCheck;
+        hash = h.at(m_algo).at(m_end);
     } catch (const std::exception &ex) {}
 
     return hash;

--- a/src/backend/common/interfaces/IWorker.h
+++ b/src/backend/common/interfaces/IWorker.h
@@ -35,6 +35,7 @@ namespace xmrig {
 
 class VirtualMemory;
 class Job;
+class Config;
 
 
 class IWorker
@@ -48,7 +49,7 @@ public:
     virtual size_t intensity() const                          = 0;
     virtual uint64_t rawHashes() const                        = 0;
     virtual void getHashrateData(uint64_t&, uint64_t&) const  = 0;
-    virtual void start()                                      = 0;
+    virtual void start(Config*)                               = 0;
     virtual void jobEarlyNotification(const Job&)             = 0;
 
 #   ifdef XMRIG_FEATURE_BENCHMARK

--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -390,7 +390,7 @@ void xmrig::CpuBackend::start(IWorker *worker, bool ready)
     mutex.unlock();
 
     if (ready) {
-        worker->start();
+        worker->start(d_ptr->controller->config());
     }
 }
 

--- a/src/backend/cpu/CpuWorker.h
+++ b/src/backend/cpu/CpuWorker.h
@@ -43,6 +43,7 @@ namespace xmrig {
 
 
 class RxVm;
+class Config;
 
 
 template<size_t N>
@@ -56,7 +57,7 @@ public:
 
 protected:
     bool selfTest() override;
-    void start() override;
+    void start(Config*) override;
 
     inline const VirtualMemory *memory() const override { return m_memory; }
     inline size_t intensity() const override            { return N; }

--- a/src/backend/cuda/CudaBackend.cpp
+++ b/src/backend/cuda/CudaBackend.cpp
@@ -481,7 +481,7 @@ void xmrig::CudaBackend::start(IWorker *worker, bool ready)
     mutex.unlock();
 
     if (ready) {
-        worker->start();
+        worker->start(d_ptr->controller->config());
     }
 }
 

--- a/src/backend/cuda/CudaWorker.cpp
+++ b/src/backend/cuda/CudaWorker.cpp
@@ -145,7 +145,7 @@ size_t xmrig::CudaWorker::intensity() const
 }
 
 
-void xmrig::CudaWorker::start()
+void xmrig::CudaWorker::start(xmrig::Config*)
 {
     while (Nonce::sequence(Nonce::CUDA) > 0) {
         if (!isReady()) {

--- a/src/backend/cuda/CudaWorker.h
+++ b/src/backend/cuda/CudaWorker.h
@@ -39,6 +39,7 @@ namespace xmrig {
 
 
 class ICudaRunner;
+class Config;
 
 
 class CudaWorker : public Worker
@@ -58,7 +59,7 @@ public:
 protected:
     bool selfTest() override;
     size_t intensity() const override;
-    void start() override;
+    void start(Config*) override;
 
 private:
     bool consumeJob();

--- a/src/backend/opencl/OclBackend.cpp
+++ b/src/backend/opencl/OclBackend.cpp
@@ -463,7 +463,7 @@ void xmrig::OclBackend::start(IWorker *worker, bool ready)
     mutex.unlock();
 
     if (ready) {
-        worker->start();
+        worker->start(d_ptr->controller->config());
     }
 }
 

--- a/src/backend/opencl/OclWorker.cpp
+++ b/src/backend/opencl/OclWorker.cpp
@@ -163,7 +163,7 @@ size_t xmrig::OclWorker::intensity() const
 }
 
 
-void xmrig::OclWorker::start()
+void xmrig::OclWorker::start(xmrig::Config*)
 {
     cl_uint results[0x100];
 

--- a/src/backend/opencl/OclWorker.h
+++ b/src/backend/opencl/OclWorker.h
@@ -40,6 +40,7 @@ namespace xmrig {
 
 class IOclRunner;
 class Job;
+class Config;
 
 
 class OclWorker : public Worker
@@ -59,7 +60,7 @@ public:
 protected:
     bool selfTest() override;
     size_t intensity() const override;
-    void start() override;
+    void start(Config*) override;
 
 private:
     bool consumeJob();

--- a/src/crypto/randomx/jit_compiler_x86.cpp
+++ b/src/crypto/randomx/jit_compiler_x86.cpp
@@ -297,7 +297,7 @@ namespace randomx {
 	}
 
 	void JitCompilerX86::generateProgramPrologue(Program& prog, ProgramConfiguration& pcfg) {
-		codePos = ((uint8_t*)randomx_program_prologue_first_load) - ((uint8_t*)randomx_program_prologue);
+		codePos = ADDR(randomx_program_prologue_first_load) - ADDR(randomx_program_prologue);
 		code[codePos + 2] = 0xc0 + pcfg.readReg0;
 		code[codePos + 5] = 0xc0 + pcfg.readReg1;
 		*(uint32_t*)(code + codePos + 10) = RandomX_CurrentConfig.ScratchpadL3Mask64_Calculated;


### PR DESCRIPTION
Each hash is dependent on the previous hash to make multi-threaded cheating impossible.