### PR TITLE
Don't use team 'x64' for '64-bit'

### DIFF
--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -88,11 +88,11 @@ static void print_cpu(Config *)
 {
     const auto info = Cpu::info();
 
-    Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s%s (%zu)") " %sx64 %sAES",
+    Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s%s (%zu)") " %s64-bit %sAES",
                "CPU",
                info->brand(),
                info->packages(),
-               info->isX64()          ? GREEN_BOLD_S : RED_BOLD_S "-",
+               info->is64bit()        ? GREEN_BOLD_S : RED_BOLD_S "-",
                info->hasAES()         ? GREEN_BOLD_S : RED_BOLD_S "-"
                );
 #   if defined(XMRIG_FEATURE_LIBCPUID) || defined (XMRIG_FEATURE_HWLOC)

--- a/src/backend/cpu/interfaces/ICpuInfo.h
+++ b/src/backend/cpu/interfaces/ICpuInfo.h
@@ -77,9 +77,9 @@ public:
     virtual ~ICpuInfo() = default;
 
 #   if defined(__x86_64__) || defined(_M_AMD64) || defined (__arm64__) || defined (__aarch64__)
-    inline constexpr static bool isX64() { return true; }
+    inline constexpr static bool is64bit() { return true; }
 #   else
-    inline constexpr static bool isX64() { return false; }
+    inline constexpr static bool is64bit() { return false; }
 #   endif
 
     virtual Assembly::Id assembly() const                                           = 0;

--- a/src/backend/cpu/platform/BasicCpuInfo.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo.cpp
@@ -344,7 +344,7 @@ rapidjson::Value xmrig::BasicCpuInfo::toJSON(rapidjson::Document &doc) const
     out.AddMember("proc_info",  m_procInfo, allocator);
     out.AddMember("aes",        hasAES(), allocator);
     out.AddMember("avx2",       hasAVX2(), allocator);
-    out.AddMember("x64",        isX64(), allocator);
+    out.AddMember("x64",        is64bit(), allocator);
     out.AddMember("l2",         static_cast<uint64_t>(L2()), allocator);
     out.AddMember("l3",         static_cast<uint64_t>(L3()), allocator);
     out.AddMember("cores",      static_cast<uint64_t>(cores()), allocator);

--- a/src/backend/cpu/platform/BasicCpuInfo_arm.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm.cpp
@@ -95,7 +95,7 @@ rapidjson::Value xmrig::BasicCpuInfo::toJSON(rapidjson::Document &doc) const
     out.AddMember("brand",      StringRef(brand()), allocator);
     out.AddMember("aes",        hasAES(), allocator);
     out.AddMember("avx2",       false, allocator);
-    out.AddMember("x64",        isX64(), allocator);
+    out.AddMember("x64",        is64bit(), allocator);
     out.AddMember("l2",         static_cast<uint64_t>(L2()), allocator);
     out.AddMember("l3",         static_cast<uint64_t>(L3()), allocator);
     out.AddMember("cores",      static_cast<uint64_t>(cores()), allocator);


### PR DESCRIPTION
`x64` is short for `x86-64`, which only refers to this specific architecture made by AMD; using the term for any other 64-bit architectures such as `arm64` is wrong. Please simply use `64-bit` to indicate a 64-bit architecture.

Source file `src/backend/cpu/platform/BasicCpuInfo_arm.cpp` would still output JSON that uses `x64` to indicate 64-bit support, should it be fixed as well?