### PR TITLE
Fix build on GCC 11

### DIFF
--- a/src/base/net/tools/MemPool.h
+++ b/src/base/net/tools/MemPool.h
@@ -24,6 +24,7 @@
 #include <set>
 #include <array>
 #include <cassert>
+#include <cstddef>
 
 
 namespace xmrig {


### PR DESCRIPTION
Currently fails with `error: 'size_t' was not declared in this scope;`, should everything be moved to `std::size_t`?