### PR TITLE
Added scripts/{build, deps} into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build
+scripts/build
+scripts/deps
 /CMakeLists.txt.user
 /.idea
 /src/backend/opencl/cl/cn/cryptonight_gen.cl


### PR DESCRIPTION
Since [build docs](https://xmrig.com/docs/miner/build/ubuntu) mentions `scripts/build_deps.sh` it's output should be added into `.gitignore`

```bash
sudo apt install -y git build-essential cmake automake libtool autoconf
git clone --depth=1 https://github.com/xmrig/xmrig.git && cd xmrig
mkdir -p build && cd scripts
./build_deps.sh && cd ../build
cd ..

LANG=en_US git status
```

```
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build/
	deps/

nothing added to commit but untracked files present (use "git add" to track)
```