### PR TITLE
Self select with origin submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v6.8.0
+- [#2052](https://github.com/xmrig/xmrig/pull/2052) Added DMI/SMBIOS reader.
+  - Added information about memory modules on the miner startup and for online benchmark.
+  - Added new HTTP API endpoint: `GET /2/dmi`.
+  - Added new command line option `--no-dmi` or config option `"dmi"`.
+  - Added new CMake option `-DWITH_DMI=OFF`.
+- [#2057](https://github.com/xmrig/xmrig/pull/2057) Improved MSR subsystem code quality.
+- [#2058](https://github.com/xmrig/xmrig/pull/2058) RandomX JIT x86: removed unnecessary instructions.
+
 # v6.7.2
 - [#2039](https://github.com/xmrig/xmrig/pull/2039) Fixed solo mining.
 

--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -155,7 +155,7 @@ static void print_memory(const Config *config)
 
         if (memory.size()) {
             Log::print(WHITE_BOLD("   %-13s") "%s: " CYAN_BOLD("%" PRIu64) CYAN(" GB ") WHITE_BOLD("%s @ %" PRIu64 " MHz ") BLACK_BOLD("%s"),
-                       "", memory.slot().data(), memory.size() / oneGiB, memory.type(), memory.speed() / 1000000ULL, memory.product().data());
+                       "", memory.id().data(), memory.size() / oneGiB, memory.type(), memory.speed() / 1000000ULL, memory.product().data());
         }
         else if (printEmpty) {
             Log::print(WHITE_BOLD("   %-13s") "%s: " BLACK_BOLD("<empty>"), "", memory.slot().data());

--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -146,7 +146,7 @@ static void print_memory(const Config *config)
         return;
     }
 
-    const bool vm = Cpu::info()->isVM();
+    const bool printEmpty = reader.memory().size() <= 8;
 
     for (const auto &memory : reader.memory()) {
         if (!memory.isValid()) {
@@ -157,12 +157,12 @@ static void print_memory(const Config *config)
             Log::print(WHITE_BOLD("   %-13s") "%s: " CYAN_BOLD("%" PRIu64) CYAN(" GB ") WHITE_BOLD("%s @ %" PRIu64 " MHz ") BLACK_BOLD("%s"),
                        "", memory.slot().data(), memory.size() / oneGiB, memory.type(), memory.speed() / 1000000ULL, memory.product().data());
         }
-        else if (!vm) {
+        else if (printEmpty) {
             Log::print(WHITE_BOLD("   %-13s") "%s: " BLACK_BOLD("<empty>"), "", memory.slot().data());
         }
     }
 
-    const auto &board = vm ? reader.system() : reader.board();
+    const auto &board = Cpu::info()->isVM() ? reader.system() : reader.board();
 
     if (board.isValid()) {
         Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s") WHITE_BOLD("%s") " - " WHITE_BOLD("%s"), "MOTHERBOARD", board.vendor().data(), board.product().data());

--- a/src/backend/common/misc/PciTopology.h
+++ b/src/backend/common/misc/PciTopology.h
@@ -1,13 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018      Lee Clagett <https://github.com/vtnerd>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -42,10 +35,15 @@ public:
     PciTopology() = default;
     PciTopology(uint32_t bus, uint32_t device, uint32_t function) : m_valid(true), m_bus(bus), m_device(device), m_function(function) {}
 
-    inline bool isValid() const        { return m_valid; }
-    inline uint8_t bus() const         { return m_bus; }
-    inline uint8_t device() const      { return m_device; }
-    inline uint8_t function() const    { return m_function; }
+    inline bool isEqual(const PciTopology &other) const     { return m_valid == other.m_valid && toUint32() == other.toUint32(); }
+    inline bool isValid() const                             { return m_valid; }
+    inline uint8_t bus() const                              { return m_bus; }
+    inline uint8_t device() const                           { return m_device; }
+    inline uint8_t function() const                         { return m_function; }
+
+    inline bool operator!=(const PciTopology &other) const  { return !isEqual(other); }
+    inline bool operator<(const PciTopology &other) const   { return toUint32() < other.toUint32(); }
+    inline bool operator==(const PciTopology &other) const  { return isEqual(other); }
 
     String toString() const
     {
@@ -60,6 +58,8 @@ public:
     }
 
 private:
+    inline uint32_t toUint32() const { return m_bus << 16 | m_device << 8 | m_function;  }
+
     bool m_valid         = false;
     uint8_t m_bus        = 0;
     uint8_t m_device     = 0;

--- a/src/backend/cpu/platform/lscpu_arm.cpp
+++ b/src/backend/cpu/platform/lscpu_arm.cpp
@@ -208,6 +208,12 @@ static const id_part hisi_part[] = {
     { -1, nullptr },
 };
 
+static const id_part apple_part[] = {
+    { 0x022, "M1" },
+    { 0x023, "M1" },
+    { -1, nullptr },
+};
+
 
 static const hw_impl hw_implementer[] = {
     { 0x41, arm_part,     "ARM" },
@@ -221,6 +227,7 @@ static const hw_impl hw_implementer[] = {
     { 0x51, qcom_part,    "Qualcomm" },
     { 0x53, samsung_part, "Samsung" },
     { 0x56, marvell_part, "Marvell" },
+    { 0x61, apple_part,   "Apple" },
     { 0x66, faraday_part, "Faraday" },
     { 0x69, intel_part,   "Intel" }
 };

--- a/src/backend/cpu/platform/lscpu_arm.cpp
+++ b/src/backend/cpu/platform/lscpu_arm.cpp
@@ -1,7 +1,7 @@
 /* XMRig
  * Copyright (c) 2018      Riku Voipio <riku.voipio@iki.fi>
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -87,16 +87,22 @@ static const id_part arm_part[] = {
     { 0xd03, "Cortex-A53" },
     { 0xd04, "Cortex-A35" },
     { 0xd05, "Cortex-A55" },
+    { 0xd06, "Cortex-A65" },
     { 0xd07, "Cortex-A57" },
     { 0xd08, "Cortex-A72" },
     { 0xd09, "Cortex-A73" },
     { 0xd0a, "Cortex-A75" },
     { 0xd0b, "Cortex-A76" },
     { 0xd0c, "Neoverse-N1" },
+    { 0xd0d, "Cortex-A77" },
+    { 0xd0e, "Cortex-A76AE" },
     { 0xd13, "Cortex-R52" },
     { 0xd20, "Cortex-M23" },
     { 0xd21, "Cortex-M33" },
+    { 0xd41, "Cortex-A78" },
+    { 0xd42, "Cortex-A78AE" },
     { 0xd4a, "Neoverse-E1" },
+    { 0xd4b, "Cortex-A78C" },
     { -1, nullptr },
 };
 
@@ -150,6 +156,7 @@ static const id_part samsung_part[] = {
 static const id_part nvidia_part[] = {
     { 0x000, "Denver" },
     { 0x003, "Denver 2" },
+    { 0x004, "Carmel" },
     { -1, nullptr },
 };
 
@@ -191,6 +198,11 @@ static const id_part intel_part[] = {
     { -1, nullptr },
 };
 
+static const struct id_part fujitsu_part[] = {
+    { 0x001, "A64FX" },
+    { -1, "unknown" },
+};
+
 static const id_part hisi_part[] = {
     { 0xd01, "Kunpeng-920" }, /* aka tsv110 */
     { -1, nullptr },
@@ -202,6 +214,7 @@ static const hw_impl hw_implementer[] = {
     { 0x42, brcm_part,    "Broadcom" },
     { 0x43, cavium_part,  "Cavium" },
     { 0x44, dec_part,     "DEC" },
+    { 0x46, fujitsu_part, "FUJITSU" },
     { 0x48, hisi_part,    "HiSilicon" },
     { 0x4e, nvidia_part,  "Nvidia" },
     { 0x50, apm_part,     "APM" },

--- a/src/backend/opencl/wrappers/AdlLib_linux.cpp
+++ b/src/backend/opencl/wrappers/AdlLib_linux.cpp
@@ -1,8 +1,8 @@
 /* XMRig
- * Copyright 2008-2018 Advanced Micro Devices, Inc.
- * Copyright 2018-2020 SChernykh                    <https://github.com/SChernykh>
- * Copyright 2020      Patrick Bollinger            <https://github.com/pjbollinger>
- * Copyright 2016-2020 XMRig                        <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2008-2018 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020      Patrick Bollinger            <https://github.com/pjbollinger>
+ * Copyright (c) 2018-2021 SChernykh                    <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig                        <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -81,7 +81,7 @@ static inline std::string sysfs_prefix(const PciTopology &topology)
 {
     const std::string path = kPrefix + "0000:" + topology.toString().data() + "/hwmon/hwmon";
 
-    for (uint32_t i = 1; i < 10; ++i) {
+    for (uint32_t i = 1; i < 100; ++i) {
         const std::string prefix = path + std::to_string(i) + "/";
         if (sysfs_is_amdgpu(prefix + "name") && (sysfs_read(prefix + "temp1_input") || sysfs_read(prefix + "power1_average"))) {
             return prefix;

--- a/src/backend/opencl/wrappers/AdlLib_linux.cpp
+++ b/src/backend/opencl/wrappers/AdlLib_linux.cpp
@@ -20,10 +20,13 @@
 
 
 #include "backend/opencl/wrappers/AdlLib.h"
+#include "3rdparty/fmt/core.h"
 #include "backend/opencl/wrappers/OclDevice.h"
 
 
+#include <dirent.h>
 #include <fstream>
+#include <map>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -35,18 +38,27 @@ namespace xmrig {
 bool AdlLib::m_initialized          = false;
 bool AdlLib::m_ready                = false;
 static const std::string kPrefix    = "/sys/bus/pci/drivers/amdgpu/";
+static std::map<PciTopology, std::string> hwmon_cache;
 
 
-static inline bool sysfs_is_file(const std::string &path)
+static inline bool sysfs_is_file(const char *path)
 {
     struct stat sb;
 
-    return stat(path.c_str(), &sb) == 0 && ((sb.st_mode & S_IFMT) == S_IFREG);
+    return stat(path, &sb) == 0 && ((sb.st_mode & S_IFMT) == S_IFREG);
 }
 
 
-static inline bool sysfs_is_amdgpu(const std::string &path)
+static inline int dir_filter(const struct dirent *dirp)
 {
+    return strlen(dirp->d_name) > 5 ? 1 : 0;
+}
+
+
+static bool sysfs_is_amdgpu(const char *path, char *buf, const char *filename)
+{
+    strcpy(buf, filename);
+
     if (!sysfs_is_file(path)) {
         return false;
     }
@@ -63,8 +75,10 @@ static inline bool sysfs_is_amdgpu(const std::string &path)
 }
 
 
-uint32_t sysfs_read(const std::string &path)
+static uint32_t sysfs_read(const char *path, char *buf, const char *filename)
 {
+    strcpy(buf, filename);
+
     std::ifstream file(path);
     if (!file.is_open()) {
         return 0;
@@ -77,18 +91,44 @@ uint32_t sysfs_read(const std::string &path)
 }
 
 
-static inline std::string sysfs_prefix(const PciTopology &topology)
+static size_t sysfs_prefix(char path[PATH_MAX], const PciTopology &topology)
 {
-    const std::string path = kPrefix + "0000:" + topology.toString().data() + "/hwmon/hwmon";
+    const auto it = hwmon_cache.find(topology);
+    if (it != hwmon_cache.end()) {
+        strcpy(path, it->second.data());
 
-    for (uint32_t i = 1; i < 100; ++i) {
-        const std::string prefix = path + std::to_string(i) + "/";
-        if (sysfs_is_amdgpu(prefix + "name") && (sysfs_read(prefix + "temp1_input") || sysfs_read(prefix + "power1_average"))) {
-            return prefix;
-        }
+        return it->second.size();
     }
 
-    return {};
+    char *base = fmt::format_to(path, "{}0000:{}/hwmon/", kPrefix, topology.toString());
+    *base      = '\0';
+    char *end  = nullptr;
+
+    struct dirent **namelist;
+    int n = scandir(path, &namelist, dir_filter, nullptr);
+    if (n < 0) {
+        return {};
+    }
+
+    while (n--) {
+        if (!end) {
+            char *tmp = fmt::format_to(base, "{}/", namelist[n]->d_name);
+            end       = (sysfs_is_amdgpu(path, tmp, "name") && (sysfs_read(path, tmp, "temp1_input") || sysfs_read(path, tmp, "power1_average"))) ? tmp : nullptr;
+        }
+
+        free(namelist[n]);
+    }
+
+    free(namelist);
+
+    if (end) {
+        *end = '\0';
+        hwmon_cache.insert({ topology, path });
+
+        return end - path;
+    }
+
+    return 0;
 }
 
 
@@ -124,20 +164,22 @@ AdlHealth xmrig::AdlLib::health(const OclDevice &device)
         return {};
     }
 
-    const auto prefix = sysfs_prefix(device.topology());
-    if (prefix.empty()) {
+    static char path[PATH_MAX]{};
+
+    char *buf = path + sysfs_prefix(path, device.topology());
+    if (buf == path) {
         return {};
     }
 
     AdlHealth health;
-    health.clock        = sysfs_read(prefix + "freq1_input") / 1000000;
-    health.memClock     = sysfs_read(prefix + "freq2_input") / 1000000;
-    health.power        = sysfs_read(prefix + "power1_average") / 1000000;
-    health.rpm          = sysfs_read(prefix + "fan1_input");
-    health.temperature  = sysfs_read(prefix + "temp2_input") / 1000;
+    health.clock        = sysfs_read(path, buf, "freq1_input") / 1000000;
+    health.memClock     = sysfs_read(path, buf, "freq2_input") / 1000000;
+    health.power        = sysfs_read(path, buf, "power1_average") / 1000000;
+    health.rpm          = sysfs_read(path, buf, "fan1_input");
+    health.temperature  = sysfs_read(path, buf, "temp2_input") / 1000;
 
     if (!health.temperature) {
-        health.temperature = sysfs_read(prefix + "temp1_input") / 1000;
+        health.temperature = sysfs_read(path, buf, "temp1_input") / 1000;
     }
 
     return health;

--- a/src/base/io/log/Tags.cpp
+++ b/src/base/io/log/Tags.cpp
@@ -36,6 +36,12 @@ const char *xmrig::Tags::network()
     return tag;
 }
 
+const char* xmrig::Tags::origin()
+{
+    static const char* tag = YELLOW_BG_BOLD(WHITE_BOLD_S " origin  ");
+
+    return tag;
+}
 
 const char *xmrig::Tags::signal()
 {

--- a/src/base/io/log/Tags.h
+++ b/src/base/io/log/Tags.h
@@ -32,6 +32,7 @@ class Tags
 public:
     static const char *config();
     static const char *network();
+    static const char *origin();
     static const char *signal();
 
 #   ifdef XMRIG_MINER_PROJECT

--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -260,6 +260,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::DryRunKey:      /* --dry-run */
     case IConfig::HttpEnabledKey: /* --http-enabled */
     case IConfig::DaemonKey:      /* --daemon */
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
     case IConfig::VerboseKey:     /* --verbose */
     case IConfig::PauseOnBatteryKey: /* --pause-on-battery */
         return transformBoolean(doc, key, true);
@@ -289,6 +290,9 @@ void xmrig::BaseTransform::transformBoolean(rapidjson::Document &doc, int key, b
 
     case IConfig::TlsKey: /* --tls */
         return add(doc, Pools::kPools, Pool::kTls, enable);
+
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
+        return add(doc, Pools::kPools, Pool::kSubmitToOrigin, enable);
 
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonKey: /* --daemon */

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -73,6 +73,7 @@ public:
         DaemonKey            = 1018,
         DaemonPollKey        = 1019,
         SelfSelectKey        = 1028,
+        SubmitToOriginKey    = 1049,
         DataDirKey           = 1035,
         TitleKey             = 1037,
         NoTitleKey           = 1038,

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -72,6 +72,7 @@ public:
     static const char *kPass;
     static const char *kRigId;
     static const char *kSelfSelect;
+    static const char* kSubmitToOrigin;
     static const char *kSOCKS5;
     static const char *kTls;
     static const char *kUrl;
@@ -156,6 +157,7 @@ private:
     uint64_t m_pollInterval         = kDefaultPollInterval;
     Url m_daemon;
     Url m_url;
+    bool m_submit_to_origin         = false;
 
 #   ifdef XMRIG_FEATURE_BENCHMARK
     std::shared_ptr<BenchConfig> m_benchmark;

--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -31,9 +31,12 @@
 #include "base/io/json/Json.h"
 #include "base/io/json/JsonRequest.h"
 #include "base/io/log/Log.h"
+#include "base/io/log/Tags.h"
 #include "base/net/http/Fetch.h"
 #include "base/net/http/HttpData.h"
 #include "base/net/stratum/Client.h"
+#include "net/JobResult.h"
+#include "base/tools/Cvt.h"
 
 
 namespace xmrig {
@@ -54,8 +57,8 @@ static const char * const required_fields[] = { kBlocktemplateBlob, kBlockhashin
 } /* namespace xmrig */
 
 
-xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener) :
-    m_listener(listener)
+xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin) :
+    m_listener(listener), m_submit_to_origin(submit_to_origin)
 {
     m_httpListener  = std::make_shared<HttpListener>(this);
     m_client        = new Client(id, agent, this);
@@ -93,7 +96,6 @@ void xmrig::SelfSelectClient::onJobReceived(IClient *, const Job &job, const rap
 void xmrig::SelfSelectClient::onLogin(IClient *, rapidjson::Document &doc, rapidjson::Value &params)
 {
     params.AddMember("mode", "self-select", doc.GetAllocator());
-
     m_listener->onLogin(this, doc, params);
 }
 
@@ -201,6 +203,9 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     Document doc(kObjectType);
     auto &allocator = doc.GetAllocator();
 
+    m_blocktemplate = Json::getString(result,kBlocktemplateBlob);
+    m_blockdiff = Json::getUint64(result, kDifficulty);
+
     Value params(kObjectType);
     params.AddMember(StringRef(kId),            m_job.clientId().toJSON(), allocator);
     params.AddMember(StringRef(kJobId),         m_job.id().toJSON(), allocator);
@@ -235,6 +240,50 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     });
 }
 
+int64_t xmrig::SelfSelectClient::submit(const JobResult& result)
+{
+    if (m_submit_to_origin) {
+        submitOriginDaemon(result);
+    }
+    return m_client->submit(result);
+}
+
+void xmrig::SelfSelectClient::submitOriginDaemon(const JobResult& result)
+{
+    if (result.diff == 0 || m_blockdiff == 0) {
+        return;
+    }
+    
+    if (result.actualDiff() < m_blockdiff) {
+        m_origin_not_submitted++;
+        LOG_DEBUG("%s " RED_BOLD("not submitted to origin daemon, difficulty too low") " (%" PRId64 "/%" PRId64 ") "
+            BLACK_BOLD(" diff ") BLACK_BOLD("%" PRIu64) BLACK_BOLD(" vs. ") BLACK_BOLD("%" PRIu64),
+            Tags::origin(), m_origin_submitted, m_origin_not_submitted, m_blockdiff, result.actualDiff());
+        return;
+    }
+    char *data = m_blocktemplate.data();
+    Cvt::toHex(data + 78, 8, reinterpret_cast<const uint8_t*>(&result.nonce), 4);
+
+    using namespace rapidjson;
+    Document doc(kObjectType);
+
+    Value params(kArrayType);
+    params.PushBack(m_blocktemplate.toJSON(), doc.GetAllocator());
+
+    JsonRequest::create(doc, m_sequence, "submitblock", params);
+    m_results[m_sequence] = SubmitResult(m_sequence, result.diff, result.actualDiff(), 0, result.backend);
+
+    FetchRequest req(HTTP_POST, pool().daemon().host(), pool().daemon().port(), "/json_rpc", doc, pool().daemon().isTLS(), isQuiet());
+    fetch(tag(), std::move(req), m_httpListener);
+    
+    m_origin_submitted++;
+    LOG_INFO("%s " GREEN_BOLD("submitted to origin daemon") " (%" PRId64 "/%" PRId64 ") " 
+        " diff " WHITE("%" PRIu64) " vs. " WHITE("%" PRIu64),
+        Tags::origin(), m_origin_submitted, m_origin_not_submitted, m_blockdiff, result.actualDiff(), result.diff);
+
+    // Ensure that the latest block template is available after block submission
+    getBlockTemplate();
+}
 
 void xmrig::SelfSelectClient::onHttpData(const HttpData &data)
 {

--- a/src/base/net/stratum/SelfSelectClient.h
+++ b/src/base/net/stratum/SelfSelectClient.h
@@ -35,6 +35,7 @@
 
 
 #include <memory>
+#include <map>
 
 
 namespace xmrig {
@@ -45,7 +46,7 @@ class SelfSelectClient : public IClient, public IClientListener, public IHttpLis
 public:
     XMRIG_DISABLE_COPY_MOVE_DEFAULT(SelfSelectClient)
 
-    SelfSelectClient(int id, const char *agent, IClientListener *listener);
+    SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin);
     ~SelfSelectClient() override;
 
 protected:
@@ -65,7 +66,7 @@ protected:
     inline int64_t send(const rapidjson::Value &obj, Callback callback) override    { return m_client->send(obj, callback); }
     inline int64_t send(const rapidjson::Value &obj) override                       { return m_client->send(obj); }
     inline int64_t sequence() const override                                        { return m_client->sequence(); }
-    inline int64_t submit(const JobResult &result) override                         { return m_client->submit(result); }
+    inline int64_t submit(const JobResult &result) override;
     inline void connect() override                                                  { m_client->connect(); }
     inline void connect(const Pool &pool) override                                  { m_client->connect(pool); }
     inline void deleteLater() override                                              { m_client->deleteLater(); }
@@ -105,7 +106,7 @@ private:
     void retry();
     void setState(State state);
     void submitBlockTemplate(rapidjson::Value &result);
-
+    inline void submitOriginDaemon(const JobResult &result);
     bool m_active           = false;
     bool m_quiet            = false;
     IClient *m_client;
@@ -115,9 +116,15 @@ private:
     int64_t m_sequence      = 1;
     Job m_job;
     State m_state           = IdleState;
+    String m_blocktemplate;
+    bool m_submit_to_origin = false;
+    std::map<int64_t, SubmitResult> m_results;
     std::shared_ptr<IHttpListener> m_httpListener;
     uint64_t m_retryPause   = 5000;
     uint64_t m_timestamp    = 0;
+    uint64_t m_blockdiff = 0;
+    uint64_t m_origin_submitted = 0;
+    uint64_t m_origin_not_submitted = 0;
 };
 
 

--- a/src/config.json
+++ b/src/config.json
@@ -80,6 +80,7 @@
     ],
     "print-time": 60,
     "health-print-time": 60,
+    "dmi": true,
     "retries": 5,
     "retry-pause": 5,
     "syslog": false,

--- a/src/config.json
+++ b/src/config.json
@@ -75,7 +75,8 @@
             "tls-fingerprint": null,
             "daemon": false,
             "socks5": null,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -1,12 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -22,6 +16,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #ifndef XMRIG_CONFIG_DEFAULT_H
 #define XMRIG_CONFIG_DEFAULT_H
 
@@ -29,6 +24,7 @@
 namespace xmrig {
 
 
+// This feature require CMake option: -DWITH_EMBEDDED_CONFIG=ON
 #ifdef XMRIG_FEATURE_EMBEDDED_CONFIG
 const static char *default_config =
 R"===(
@@ -45,9 +41,9 @@ R"===(
         "restricted": true
     },
     "autosave": true,
-    "version": 1,
     "background": false,
     "colors": true,
+    "title": true,
     "randomx": {
         "init": -1,
         "init-avx2": -1,
@@ -80,6 +76,7 @@ R"===(
         "cache": true,
         "loader": null,
         "platform": "AMD",
+        "adl": true,
         "cn/0": false,
         "cn-lite/0": false
     },
@@ -90,7 +87,7 @@ R"===(
         "cn/0": false,
         "cn-lite/0": false
     },
-    "donate-level": 5,
+    "donate-level": 1,
     "donate-over-proxy": 1,
     "log-file": null,
     "pools": [
@@ -107,15 +104,27 @@ R"===(
             "tls": false,
             "tls-fingerprint": null,
             "daemon": false,
+            "socks5": null,
             "self-select": null
         }
     ],
     "print-time": 60,
     "health-print-time": 60,
+    "dmi": true,
     "retries": 5,
     "retry-pause": 5,
     "syslog": false,
+    "tls": {
+        "enabled": false,
+        "protocols": null,
+        "cert": null,
+        "cert_key": null,
+        "ciphers": null,
+        "ciphersuites": null,
+        "dhparam": null
+    },
     "user-agent": null,
+    "verbose": 0,
     "watch": true,
     "pause-on-battery": false
 }

--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -104,8 +104,10 @@ R"===(
             "tls": false,
             "tls-fingerprint": null,
             "daemon": false,
+
             "socks5": null,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -57,6 +57,7 @@ static const option options[] = {
     { "daemon",                0, nullptr, IConfig::DaemonKey             },
     { "daemon-poll-interval",  1, nullptr, IConfig::DaemonPollKey         },
     { "self-select",           1, nullptr, IConfig::SelfSelectKey         },
+    { "submit-to-origin",      0, nullptr, IConfig::SubmitToOriginKey     },
 #   endif
     { "av",                    1, nullptr, IConfig::AVKey                 },
     { "background",            0, nullptr, IConfig::BackgroundKey         },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -64,6 +64,7 @@ static inline const std::string &usage()
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";
     u += "      --daemon-poll-interval=N  daemon poll interval in milliseconds (default: 1000)\n";
     u += "      --self-select=URL         self-select block templates from URL\n";
+    u += "      --submit-to-origin        also submit solution back to self-select URL\n";
 #   endif
 
     u += "  -r, --retries=N               number of times to retry before switch to backup server (default: 5)\n";

--- a/src/hw/dmi/DmiMemory.cpp
+++ b/src/hw/dmi/DmiMemory.cpp
@@ -20,15 +20,20 @@
 
 
 #include "hw/dmi/DmiMemory.h"
+#include "3rdparty/fmt/format.h"
 #include "3rdparty/rapidjson/document.h"
 #include "hw/dmi/DmiTools.h"
 
 
 #include <algorithm>
 #include <array>
+#include <regex>
 
 
 namespace xmrig {
+
+
+static const char *kIdFormat = "DIMM_{}{}";
 
 
 static inline uint16_t dmi_memory_device_width(uint16_t code)
@@ -143,9 +148,9 @@ xmrig::DmiMemory::DmiMemory(dmi_header *h)
         m_size = (1024ULL * (size & 0x7FFF) * ((size & 0x8000) ? 1 : 1024ULL));
     }
 
+    setId(dmi_string(h, 0x10), dmi_string(h, 0x11));
+
     m_formFactor = h->data[0x0E];
-    m_slot       = dmi_string(h, 0x10);
-    m_bank       = dmi_string(h, 0x11);
     m_type       = h->data[0x12];
 
     if (!m_size || h->length < 0x17) {
@@ -201,6 +206,7 @@ rapidjson::Value xmrig::DmiMemory::toJSON(rapidjson::Document &doc) const
 
     auto &allocator = doc.GetAllocator();
     Value out(kObjectType);
+    out.AddMember("id",             id().toJSON(doc), allocator);
     out.AddMember("slot",           m_slot.toJSON(doc), allocator);
     out.AddMember("type",           StringRef(type()), allocator);
     out.AddMember("form_factor",    StringRef(formFactor()), allocator);
@@ -217,3 +223,21 @@ rapidjson::Value xmrig::DmiMemory::toJSON(rapidjson::Document &doc) const
     return out;
 }
 #endif
+
+
+void xmrig::DmiMemory::setId(const char *slot, const char *bank)
+{
+    m_slot = slot;
+    m_bank = bank;
+
+    std::cmatch cm;
+    if (std::regex_match(slot, cm, std::regex("^Channel([A-Z])-DIMM(\\d+)$"))) {
+        m_id = fmt::format(kIdFormat, cm.str(1), cm.str(2)).c_str();
+    }
+    else if (std::regex_search(bank, cm, std::regex("CHANNEL ([A-Z])$"))) {
+        std::cmatch cm2;
+        if (std::regex_match(slot, cm2, std::regex("^DIMM (\\d+)$"))) {
+            m_id = fmt::format(kIdFormat, cm.str(1), cm2.str(1)).c_str();
+        }
+    }
+}

--- a/src/hw/dmi/DmiMemory.cpp
+++ b/src/hw/dmi/DmiMemory.cpp
@@ -231,7 +231,7 @@ void xmrig::DmiMemory::setId(const char *slot, const char *bank)
     m_bank = bank;
 
     std::cmatch cm;
-    if (std::regex_match(slot, cm, std::regex("^Channel([A-Z])-DIMM(\\d+)$"))) {
+    if (std::regex_match(slot, cm, std::regex("^Channel([A-Z])[-_]DIMM(\\d+)$", std::regex_constants::icase))) {
         m_id = fmt::format(kIdFormat, cm.str(1), cm.str(2)).c_str();
     }
     else if (std::regex_search(bank, cm, std::regex("CHANNEL ([A-Z])$"))) {

--- a/src/hw/dmi/DmiMemory.h
+++ b/src/hw/dmi/DmiMemory.h
@@ -39,6 +39,7 @@ public:
 
     inline bool isValid() const             { return !m_slot.isEmpty(); }
     inline const String &bank() const       { return m_bank; }
+    inline const String &id() const         { return m_id.isNull() ? m_slot : m_id; }
     inline const String &product() const    { return m_product; }
     inline const String &slot() const       { return m_slot; }
     inline const String &vendor() const     { return m_vendor; }
@@ -57,7 +58,10 @@ public:
 #   endif
 
 private:
+    void setId(const char *slot, const char *bank);
+
     String m_bank;
+    String m_id;
     String m_product;
     String m_slot;
     String m_vendor;

--- a/src/version.h
+++ b/src/version.h
@@ -28,7 +28,7 @@
 #define APP_ID        "xmrig"
 #define APP_NAME      "XMRig"
 #define APP_DESC      "XMRig miner"
-#define APP_VERSION   "6.8.0"
+#define APP_VERSION   "6.8.1-dev"
 #define APP_DOMAIN    "xmrig.com"
 #define APP_SITE      "www.xmrig.com"
 #define APP_COPYRIGHT "Copyright (C) 2016-2021 xmrig.com"
@@ -36,7 +36,7 @@
 
 #define APP_VER_MAJOR  6
 #define APP_VER_MINOR  8
-#define APP_VER_PATCH  0
+#define APP_VER_PATCH  1
 
 #ifdef _MSC_VER
 #   if (_MSC_VER >= 1920)


### PR DESCRIPTION
Allow result submission to origin daemon with self-select.

With `self-select` mode enabled, the `submit-to-origin` config option will let the `SelfSelectClient` submit the solution to both the origin daemon where it got the template from as well as to the connected pool.

This will enable pool mining for Monero in conjunction with solo merged mining with an altcoin.

Thank you and special credit to @StriderDM (https://github.com/StriderDM)!

**Update:** 
- ~~_The information sent back to the origin daemon includes both the template solution as well as the achieved difficulty so that the origin daemon can make an informed decision about submitting the result to the altcoin or not without having to re-calculate the achieved difficulty._~~
- _Submission to the origin daemon will only be done if achieved difficulty is equal to or higher than the target difficulty received with the block template._

Example console output:
``` rust
 * ABOUT        XMRig/6.7.3-dev MSVC/2019
 * LIBS         libuv/1.40.0 OpenSSL/1.1.1h
 * HUGE PAGES   permission granted
 * 1GB PAGES    unavailable
 * CPU          Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (1) 64-bit AES VM
                threads:8
 * MEMORY       12.1/31.9 GB (38%)
 * DONATE       1%
 * ASSEMBLY     auto:intel
 * POOL #1      cryptonote.social:5555 coin monero self-select 127.0.0.1:7878 submit-to-origin
 * COMMANDS     hashrate, pause, resume, results, connection
 * OPENCL       disabled
 * CUDA         disabled
[2021-01-18 11:40:32.206]  net      use pool cryptonote.social:5555  75.144.254.101
[2021-01-18 11:40:33.235]  net      new job from cryptonote.social:5555 diff 220006 algo rx/0 height 2277083
[2021-01-18 11:40:33.235]  cpu      use argon2 implementation AVX2
[2021-01-18 11:40:33.413]  msr      register values for "intel" preset has been set successfully (177 ms)
[2021-01-18 11:40:33.413]  randomx  init dataset algo rx/0 (8 threads) seed c16b9816e30cf2bc...
[2021-01-18 11:40:33.863]  randomx  allocated 2336 MB (2080+256) huge pages 100% 1168/1168 +JIT (450 ms)
[2021-01-18 11:40:38.199]  randomx  dataset ready (4336 ms)
[2021-01-18 11:40:38.200]  cpu      use profile  rx  (4 threads) scratchpad 2048 KB
[2021-01-18 11:40:38.262]  cpu      READY threads 4/4 (4) huge pages 100% 4/4 memory 8192 KB (62 ms)
[2021-01-18 11:40:48.392]  net      new job from cryptonote.social:5555 diff 220006 algo rx/0 height 2277084
[2021-01-18 11:41:22.378]  origin   submitted to origin daemon (1/0)  diff 284557 vs. 371742
[2021-01-18 11:41:22.812]  cpu      accepted (1/0) diff 220006 (433 ms)
[2021-01-18 11:41:39.201]  miner    speed 10s/60s/15m 1562.2 1630.4 n/a H/s max 1710.0 H/s
[2021-01-18 11:42:05.837]  origin   not submitted to origin daemon, difficulty too low (1/1)  diff 284557 vs. 230465
[2021-01-18 11:42:06.320]  cpu      accepted (2/0) diff 220006 (482 ms)
```