### PR TITLE
Add missing "cstdio" library

### DIFF
--- a/src/hw/dmi/DmiReader_unix.cpp
+++ b/src/hw/dmi/DmiReader_unix.cpp
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-
+#include <cstdio>
 
 #ifdef __FreeBSD__
 #   include <kenv.h>


### PR DESCRIPTION
Compilation fails if the above library is missing. This fixes a compilation error.