### PR TITLE
Added support for flexible huge page sizes on Linux.

### DIFF
--- a/src/backend/cpu/CpuConfig.cpp
+++ b/src/backend/cpu/CpuConfig.cpp
@@ -1,12 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -77,7 +71,7 @@ rapidjson::Value xmrig::CpuConfig::toJSON(rapidjson::Document &doc) const
     Value obj(kObjectType);
 
     obj.AddMember(StringRef(kEnabled),      m_enabled, allocator);
-    obj.AddMember(StringRef(kHugePages),    m_hugePages, allocator);
+    obj.AddMember(StringRef(kHugePages),    m_hugePageSize == 0 || m_hugePageSize == kDefaultHugePageSizeKb ? Value(isHugePages()) : Value(m_hugePageSize), allocator);
     obj.AddMember(StringRef(kHugePagesJit), m_hugePagesJit, allocator);
     obj.AddMember(StringRef(kHwAes),        m_aes == AES_AUTO ? Value(kNullType) : Value(m_aes == AES_HW), allocator);
     obj.AddMember(StringRef(kPriority),     priority() != -1 ? Value(priority()) : Value(kNullType), allocator);
@@ -137,14 +131,14 @@ void xmrig::CpuConfig::read(const rapidjson::Value &value)
 {
     if (value.IsObject()) {
         m_enabled      = Json::getBool(value, kEnabled, m_enabled);
-        m_hugePages    = Json::getBool(value, kHugePages, m_hugePages);
         m_hugePagesJit = Json::getBool(value, kHugePagesJit, m_hugePagesJit);
         m_limit        = Json::getUint(value, kMaxThreadsHint, m_limit);
         m_yield        = Json::getBool(value, kYield, m_yield);
 
         setAesMode(Json::getValue(value, kHwAes));
-        setPriority(Json::getInt(value,  kPriority, -1));
+        setHugePages(Json::getValue(value, kHugePages));
         setMemoryPool(Json::getValue(value, kMemoryPool));
+        setPriority(Json::getInt(value,  kPriority, -1));
 
 #       ifdef XMRIG_FEATURE_ASM
         m_assembly = Json::getValue(value, kAsm);
@@ -214,6 +208,19 @@ void xmrig::CpuConfig::setAesMode(const rapidjson::Value &value)
     }
     else {
         m_aes = AES_AUTO;
+    }
+}
+
+
+void xmrig::CpuConfig::setHugePages(const rapidjson::Value &value)
+{
+    if (value.IsBool()) {
+        m_hugePageSize = value.GetBool() ? kDefaultHugePageSizeKb : 0U;
+    }
+    else if (value.IsUint()) {
+        const uint32_t size = value.GetUint();
+
+        m_hugePageSize = size < kOneGbPageSizeKb ? size : kDefaultHugePageSizeKb;
     }
 }
 

--- a/src/backend/cpu/CpuConfig.h
+++ b/src/backend/cpu/CpuConfig.h
@@ -1,12 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -75,8 +69,9 @@ public:
     std::vector<CpuLaunchData> get(const Miner *miner, const Algorithm &algorithm) const;
     void read(const rapidjson::Value &value);
 
+    inline bool astrobwtAVX2() const                    { return m_astrobwtAVX2; }
     inline bool isEnabled() const                       { return m_enabled; }
-    inline bool isHugePages() const                     { return m_hugePages; }
+    inline bool isHugePages() const                     { return m_hugePageSize > 0; }
     inline bool isHugePagesJit() const                  { return m_hugePagesJit; }
     inline bool isShouldSave() const                    { return m_shouldSave; }
     inline bool isYield() const                         { return m_yield; }
@@ -84,13 +79,17 @@ public:
     inline const String &argon2Impl() const             { return m_argon2Impl; }
     inline const Threads<CpuThreads> &threads() const   { return m_threads; }
     inline int astrobwtMaxSize() const                  { return m_astrobwtMaxSize; }
-    inline bool astrobwtAVX2() const                    { return m_astrobwtAVX2; }
     inline int priority() const                         { return m_priority; }
+    inline size_t hugePageSize() const                  { return m_hugePageSize * 1024U; }
     inline uint32_t limit() const                       { return m_limit; }
 
 private:
+    constexpr static size_t kDefaultHugePageSizeKb  = 2048U;
+    constexpr static size_t kOneGbPageSizeKb        = 1048576U;
+
     void generate();
     void setAesMode(const rapidjson::Value &value);
+    void setHugePages(const rapidjson::Value &value);
     void setMemoryPool(const rapidjson::Value &value);
 
     inline void setPriority(int priority)   { m_priority = (priority >= -1 && priority <= 5) ? priority : -1; }
@@ -99,13 +98,13 @@ private:
     Assembly m_assembly;
     bool m_astrobwtAVX2     = false;
     bool m_enabled          = true;
-    bool m_hugePages        = true;
     bool m_hugePagesJit     = false;
     bool m_shouldSave       = false;
     bool m_yield            = true;
     int m_astrobwtMaxSize   = 550;
     int m_memoryPool        = 0;
     int m_priority          = -1;
+    size_t m_hugePageSize   = kDefaultHugePageSizeKb;
     String m_argon2Impl;
     Threads<CpuThreads> m_threads;
     uint32_t m_limit        = 100;

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -85,6 +85,7 @@ public:
         BenchHashKey         = 1047,
         BenchTokenKey        = 1048,
         DmiKey               = 1049,
+        HugePageSizeKey      = 1050,
 
         // xmrig common
         CPUPriorityKey       = 1021,

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -50,7 +50,7 @@ int xmrig::Controller::init()
 {
     Base::init();
 
-    VirtualMemory::init(config()->cpu().memPoolSize(), config()->cpu().isHugePages());
+    VirtualMemory::init(config()->cpu().memPoolSize(), config()->cpu().hugePageSize());
 
     m_network = std::make_shared<Network>(this);
 

--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -125,9 +125,10 @@ void xmrig::ConfigTransform::transform(rapidjson::Document &doc, int key, const 
     BaseTransform::transform(doc, key, arg);
 
     switch (key) {
-    case IConfig::AVKey:          /* --av */
-    case IConfig::CPUPriorityKey: /* --cpu-priority */
-    case IConfig::ThreadsKey:     /* --threads */
+    case IConfig::AVKey:           /* --av */
+    case IConfig::CPUPriorityKey:  /* --cpu-priority */
+    case IConfig::ThreadsKey:      /* --threads */
+    case IConfig::HugePageSizeKey: /* --hugepage-size */
         return transformUint64(doc, key, static_cast<uint64_t>(strtol(arg, nullptr, 10)));
 
     case IConfig::HugePagesKey: /* --no-huge-pages */
@@ -305,6 +306,9 @@ void xmrig::ConfigTransform::transformUint64(rapidjson::Document &doc, int key, 
 
     case IConfig::CPUPriorityKey: /* --cpu-priority */
         return set(doc, CpuConfig::kField, CpuConfig::kPriority, arg);
+
+    case IConfig::HugePageSizeKey: /* --hugepage-size */
+        return set(doc, CpuConfig::kField, CpuConfig::kHugePages, arg);
 
     default:
         break;

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -71,6 +71,8 @@ static const option options[] = {
     { "nicehash",              0, nullptr, IConfig::NicehashKey           },
     { "no-color",              0, nullptr, IConfig::ColorKey              },
     { "no-huge-pages",         0, nullptr, IConfig::HugePagesKey          },
+    { "no-hugepages",          0, nullptr, IConfig::HugePagesKey          },
+    { "hugepage-size",         1, nullptr, IConfig::HugePageSizeKey       },
     { "pass",                  1, nullptr, IConfig::PasswordKey           },
     { "print-time",            1, nullptr, IConfig::PrintTimeKey          },
     { "retries",               1, nullptr, IConfig::RetriesKey            },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -83,6 +83,9 @@ static inline const std::string &usage()
     u += "      --cpu-memory-pool=N       number of 2 MB pages for persistent memory pool, -1 (auto), 0 (disable)\n";
     u += "      --cpu-no-yield            prefer maximum hashrate rather than system response/stability\n";
     u += "      --no-huge-pages           disable huge pages support\n";
+#   ifdef XMRIG_OS_LINUX
+    u += "      --hugepage-size=N         custom hugepage size in kB\n";
+#   endif
     u += "      --asm=ASM                 ASM optimizations, possible values: auto, none, intel, ryzen, bulldozer\n";
 
 #   if defined(__x86_64__) || defined(_M_AMD64)
@@ -155,7 +158,7 @@ static inline const std::string &usage()
 
     u += "  -l, --log-file=FILE           log all output to a file\n";
     u += "      --print-time=N            print hashrate report every N seconds\n";
-#   ifdef XMRIG_FEATURE_NVML
+#   if defined(XMRIG_FEATURE_NVML) || defined(XMRIG_FEATURE_ADL)
     u += "      --health-print-time=N     print health report every N seconds\n";
 #   endif
     u += "      --no-color                disable colored output\n";

--- a/src/crypto/common/HugePagesInfo.cpp
+++ b/src/crypto/common/HugePagesInfo.cpp
@@ -1,12 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -27,24 +21,16 @@
 #include "crypto/common/VirtualMemory.h"
 
 
-namespace xmrig {
-
-constexpr size_t twoMiB = 2U * 1024U * 1024U;
-constexpr size_t oneGiB = 1024U * 1024U * 1024U;
-
-} // namespace xmrig
-
-
 xmrig::HugePagesInfo::HugePagesInfo(const VirtualMemory *memory)
 {
     if (memory->isOneGbPages()) {
-        size        = VirtualMemory::align(memory->size(), oneGiB);
-        total       = size / oneGiB;
-        allocated   = size / oneGiB;
+        size        = VirtualMemory::align(memory->size(), VirtualMemory::kOneGiB);
+        total       = size / VirtualMemory::kOneGiB;
+        allocated   = size / VirtualMemory::kOneGiB;
     }
     else {
-        size        = memory->size();
-        total       = size / twoMiB;
+        size        = VirtualMemory::alignToHugePageSize(memory->size());
+        total       = size / VirtualMemory::hugePageSize();
         allocated   = memory->isHugePages() ? total : 0;
     }
 }

--- a/src/crypto/common/HugePagesInfo.h
+++ b/src/crypto/common/HugePagesInfo.h
@@ -1,12 +1,6 @@
 /* XMRig
- * Copyright 2010      Jeff Garzik <jgarzik@pobox.com>
- * Copyright 2012-2014 pooler      <pooler@litecoinpool.org>
- * Copyright 2014      Lucas Jones <https://github.com/lucasjones>
- * Copyright 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
- * Copyright 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright 2017-2018 XMR-Stak    <https://github.com/fireice-uk>, <https://github.com/psychocrypt>
- * Copyright 2018-2019 SChernykh   <https://github.com/SChernykh>
- * Copyright 2016-2019 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/src/crypto/common/LinuxMemory.cpp
+++ b/src/crypto/common/LinuxMemory.cpp
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -18,8 +18,6 @@
 
 #include "crypto/common/LinuxMemory.h"
 #include "3rdparty/fmt/core.h"
-#include "backend/cpu/Cpu.h"
-#include "base/io/log/Log.h"
 #include "crypto/common/VirtualMemory.h"
 
 
@@ -37,33 +35,32 @@ constexpr size_t twoMiB = 2U * 1024U * 1024U;
 constexpr size_t oneGiB = 1024U * 1024U * 1024U;
 
 
-static inline std::string sysfs_path(uint32_t node, bool oneGbPages, bool nr)
+static inline std::string sysfs_path(uint32_t node, size_t hugePageSize, bool nr)
 {
-    return fmt::format("/sys/devices/system/node/node{}/hugepages/hugepages-{}kB/{}_hugepages", node, oneGbPages ? "1048576" : "2048", nr ? "nr" : "free");
+    return fmt::format("/sys/devices/system/node/node{}/hugepages/hugepages-{}kB/{}_hugepages", node, hugePageSize / 1024, nr ? "nr" : "free");
 }
 
 
-static inline bool write_nr_hugepages(uint32_t node, bool oneGbPages, uint64_t count)    { return LinuxMemory::write(sysfs_path(node, oneGbPages, true).c_str(), count); }
-static inline int64_t free_hugepages(uint32_t node, bool oneGbPages)                     { return LinuxMemory::read(sysfs_path(node, oneGbPages, false).c_str()); }
-static inline int64_t nr_hugepages(uint32_t node, bool oneGbPages)                       { return LinuxMemory::read(sysfs_path(node, oneGbPages, true).c_str()); }
+static inline bool write_nr_hugepages(uint32_t node, size_t hugePageSize, uint64_t count)   { return LinuxMemory::write(sysfs_path(node, hugePageSize, true).c_str(), count); }
+static inline int64_t free_hugepages(uint32_t node, size_t hugePageSize)                    { return LinuxMemory::read(sysfs_path(node, hugePageSize, false).c_str()); }
+static inline int64_t nr_hugepages(uint32_t node, size_t hugePageSize)                      { return LinuxMemory::read(sysfs_path(node, hugePageSize, true).c_str()); }
 
 
 } // namespace xmrig
 
 
-bool xmrig::LinuxMemory::reserve(size_t size, uint32_t node, bool oneGbPages)
+bool xmrig::LinuxMemory::reserve(size_t size, uint32_t node, size_t hugePageSize)
 {
     std::lock_guard<std::mutex> lock(mutex);
 
-    const size_t pageSize = oneGbPages ? oneGiB : twoMiB;
-    const size_t required = VirtualMemory::align(size, pageSize) / pageSize;
+    const size_t required = VirtualMemory::align(size, hugePageSize) / hugePageSize;
 
-    const auto available = free_hugepages(node, oneGbPages);
+    const auto available = free_hugepages(node, hugePageSize);
     if (available < 0 || static_cast<size_t>(available) >= required) {
         return false;
     }
 
-    return write_nr_hugepages(node, oneGbPages, std::max<size_t>(nr_hugepages(node, oneGbPages), 0) + (required - available));
+    return write_nr_hugepages(node, hugePageSize, std::max<size_t>(nr_hugepages(node, hugePageSize), 0) + (required - available));
 }
 
 

--- a/src/crypto/common/LinuxMemory.h
+++ b/src/crypto/common/LinuxMemory.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ namespace xmrig {
 class LinuxMemory
 {
 public:
-    static bool reserve(size_t size, uint32_t node, bool oneGbPages = false);
+    static bool reserve(size_t size, uint32_t node, size_t hugePageSize);
 
     static bool write(const char *path, uint64_t value);
     static int64_t read(const char *path);

--- a/src/crypto/common/VirtualMemory_unix.cpp
+++ b/src/crypto/common/VirtualMemory_unix.cpp
@@ -1,7 +1,7 @@
 /* XMRig
  * Copyright (c) 2018-2020 tevador     <tevador@gmail.com>
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -18,13 +18,14 @@
  */
 
 
-#include <cstdlib>
-#include <sys/mman.h>
-
-
+#include "crypto/common/VirtualMemory.h"
 #include "backend/cpu/Cpu.h"
 #include "crypto/common/portable/mm_malloc.h"
-#include "crypto/common/VirtualMemory.h"
+
+
+#include <cmath>
+#include <cstdlib>
+#include <sys/mman.h>
 
 
 #ifdef XMRIG_OS_APPLE
@@ -42,11 +43,18 @@
 #endif
 
 
-#if defined(XMRIG_OS_LINUX)
-#   if (defined(MAP_HUGE_1GB) || defined(MAP_HUGE_SHIFT))
-#       define XMRIG_HAS_1GB_PAGES
-#   endif
+#ifdef XMRIG_OS_LINUX
 #   include "crypto/common/LinuxMemory.h"
+#endif
+
+
+#ifndef MAP_HUGE_SHIFT
+#   define MAP_HUGE_SHIFT 26
+#endif
+
+
+#ifndef MAP_HUGE_MASK
+#   define MAP_HUGE_MASK 0x3f
 #endif
 
 
@@ -55,6 +63,18 @@
 #else
 #   define SECURE_PROT_EXEC PROT_EXEC
 #endif
+
+
+namespace xmrig {
+
+
+static inline int hugePagesFlag(size_t size)
+{
+    return (static_cast<int>(log2(size)) & MAP_HUGE_MASK) << MAP_HUGE_SHIFT;
+}
+
+
+} // namespace xmrig
 
 
 bool xmrig::VirtualMemory::isHugepagesAvailable()
@@ -69,7 +89,7 @@ bool xmrig::VirtualMemory::isHugepagesAvailable()
 
 bool xmrig::VirtualMemory::isOneGbPagesAvailable()
 {
-#   ifdef XMRIG_HAS_1GB_PAGES
+#   ifdef XMRIG_OS_LINUX
     return Cpu::info()->hasOneGbPages();
 #   else
     return false;
@@ -126,18 +146,10 @@ void *xmrig::VirtualMemory::allocateExecutableMemory(size_t size, bool hugePages
 
 #   else
 
-#   if defined(MAP_HUGE_2MB)
-    constexpr int flag_2mb = MAP_HUGE_2MB;
-#   elif defined(MAP_HUGE_SHIFT)
-    constexpr int flag_2mb = (21 << MAP_HUGE_SHIFT);
-#   else
-    constexpr int flag_2mb = 0;
-#   endif
-
     void *mem = nullptr;
 
     if (hugePages) {
-        mem = mmap(0, align(size), PROT_READ | PROT_WRITE | SECURE_PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE | flag_2mb, -1, 0);
+        mem = mmap(0, align(size), PROT_READ | PROT_WRITE | SECURE_PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE | hugePagesFlag(hugePageSize()), -1, 0);
     }
 
     if (!mem) {
@@ -157,17 +169,7 @@ void *xmrig::VirtualMemory::allocateLargePagesMemory(size_t size)
 #   elif defined(__FreeBSD__)
     void *mem = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_ALIGNED_SUPER | MAP_PREFAULT_READ, -1, 0);
 #   else
-
-#   if defined(MAP_HUGE_2MB)
-    constexpr int flag_2mb = MAP_HUGE_2MB;
-#   elif defined(MAP_HUGE_SHIFT)
-    constexpr int flag_2mb = (21 << MAP_HUGE_SHIFT);
-#   else
-    constexpr int flag_2mb = 0;
-#   endif
-
-    void *mem = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE | flag_2mb, 0, 0);
-
+    void *mem = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE | hugePagesFlag(hugePageSize()), 0, 0);
 #   endif
 
     return mem == MAP_FAILED ? nullptr : mem;
@@ -176,17 +178,9 @@ void *xmrig::VirtualMemory::allocateLargePagesMemory(size_t size)
 
 void *xmrig::VirtualMemory::allocateOneGbPagesMemory(size_t size)
 {
-#   ifdef XMRIG_HAS_1GB_PAGES
+#   ifdef XMRIG_OS_LINUX
     if (isOneGbPagesAvailable()) {
-#       if defined(MAP_HUGE_1GB)
-        constexpr int flag_1gb = MAP_HUGE_1GB;
-#       elif defined(MAP_HUGE_SHIFT)
-        constexpr int flag_1gb = (30 << MAP_HUGE_SHIFT);
-#       else
-        constexpr int flag_1gb = 0;
-#       endif
-
-        void *mem = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE | flag_1gb, 0, 0);
+        void *mem = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE | hugePagesFlag(kOneGiB), 0, 0);
 
         return mem == MAP_FAILED ? nullptr : mem;
     }
@@ -212,15 +206,18 @@ void xmrig::VirtualMemory::freeLargePagesMemory(void *p, size_t size)
 }
 
 
-void xmrig::VirtualMemory::osInit(bool)
+void xmrig::VirtualMemory::osInit(size_t hugePageSize)
 {
+    if (hugePageSize) {
+        m_hugePageSize = hugePageSize;
+    }
 }
 
 
 bool xmrig::VirtualMemory::allocateLargePagesMemory()
 {
-#   if defined(XMRIG_OS_LINUX)
-    LinuxMemory::reserve(m_size, m_node);
+#   ifdef XMRIG_OS_LINUX
+    LinuxMemory::reserve(m_size, m_node, hugePageSize());
 #   endif
 
     m_scratchpad = static_cast<uint8_t*>(allocateLargePagesMemory(m_size));
@@ -242,8 +239,8 @@ bool xmrig::VirtualMemory::allocateLargePagesMemory()
 
 bool xmrig::VirtualMemory::allocateOneGbPagesMemory()
 {
-#   if defined(XMRIG_HAS_1GB_PAGES)
-    LinuxMemory::reserve(m_size, m_node, true);
+#   ifdef XMRIG_OS_LINUX
+    LinuxMemory::reserve(m_size, m_node, kOneGiB);
 #   endif
 
     m_scratchpad = static_cast<uint8_t*>(allocateOneGbPagesMemory(m_size));

--- a/src/crypto/common/VirtualMemory_win.cpp
+++ b/src/crypto/common/VirtualMemory_win.cpp
@@ -1,7 +1,7 @@
 /* XMRig
  * Copyright (c) 2018-2020 tevador     <tevador@gmail.com>
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -24,9 +24,9 @@
 #include <tchar.h>
 
 
+#include "crypto/common/VirtualMemory.h"
 #include "base/io/log/Log.h"
 #include "crypto/common/portable/mm_malloc.h"
-#include "crypto/common/VirtualMemory.h"
 
 
 #ifdef XMRIG_SECURE_JIT
@@ -233,9 +233,9 @@ void xmrig::VirtualMemory::freeLargePagesMemory(void *p, size_t)
 }
 
 
-void xmrig::VirtualMemory::osInit(bool hugePages)
+void xmrig::VirtualMemory::osInit(size_t hugePageSize)
 {
-    if (hugePages) {
+    if (hugePageSize) {
         hugepagesAvailable = TrySetLockPagesPrivilege();
     }
 }


### PR DESCRIPTION
This PR adds support for user configurable huge page sizes on Linux where huge pages with size other than 2 MB are supported. For example #2060 right now Linux on Apple M1 supports only 32 MB hugepages and doesn't support widely supported 2 MB huge pages. Also 32 MB and 64 kB huge pages can be tested on modern Amazon ARM instances with Neoverse N1 CPU (`*6g.*`)

Config option `"huge-pages"` extended, now it accepts huge pages size in kB, not only boolean value.
Examples:
- `"huge-pages": 2048,` this equal to `"huge-pages": true` default value for 2 MB huge pages.
- `"huge-pages": 32768,` - 32 MB huge pages.
- `"huge-pages": 64,` - 64 kB huge pages.

For command line usage added option `--hugepage-size`. 1 GB pages is not a valid option, since they are already supported in a special way. This PR was checked with 64 kB, 2 MB and 32 MB huge page sizes, but it should support other sizes if it is supported by hardware and Linux.