### PR TITLE
Add stdin pipe fallback for commands

### DIFF
--- a/src/base/io/Console.cpp
+++ b/src/base/io/Console.cpp
@@ -33,7 +33,7 @@ xmrig::Console::Console(IConsoleListener *listener)
     m_input->data = this;
     uv_tty_init(uv_default_loop(), reinterpret_cast<uv_tty_t*>(m_input), 0, 1);
 
-    if (!uv_is_readable(reinterpret_cast<uv_stream_t*>(m_input))) {
+    if (uv_is_readable(reinterpret_cast<uv_stream_t*>(m_input))) {
         uv_tty_set_mode(reinterpret_cast<uv_tty_t*>(m_input), UV_TTY_MODE_RAW);
         uv_read_start(m_input, Console::onAllocBuffer, Console::onRead);
     } else {

--- a/src/base/io/Console.cpp
+++ b/src/base/io/Console.cpp
@@ -29,16 +29,25 @@ xmrig::Console::Console(IConsoleListener *listener)
         return;
     }
 
-    m_tty = new uv_tty_t;
-    m_tty->data = this;
-    uv_tty_init(uv_default_loop(), m_tty, 0, 1);
+    m_input = reinterpret_cast<uv_stream_t*>(new uv_tty_t);
+    m_input->data = this;
+    uv_tty_init(uv_default_loop(), reinterpret_cast<uv_tty_t*>(m_input), 0, 1);
 
-    if (!uv_is_readable(reinterpret_cast<uv_stream_t*>(m_tty))) {
-        return;
+    if (!uv_is_readable(reinterpret_cast<uv_stream_t*>(m_input))) {
+        uv_tty_set_mode(reinterpret_cast<uv_tty_t*>(m_input), UV_TTY_MODE_RAW);
+        uv_read_start(m_input, Console::onAllocBuffer, Console::onRead);
+    } else {
+        /* Direct TTY connection doesn't work, so use stdin as pipe as fallback. 
+         * N.B. Requires pipe to be flushed on the producer side before it is received in our stdin. 
+         * For example if you run xmrig from another process and send commands to the stdin of the xmrig process, 
+         * flush that stream after writing a character to it.
+         */
+        m_input = reinterpret_cast<uv_stream_t*>(new uv_pipe_t);
+        m_input->data = this;
+        int r = uv_pipe_init(uv_default_loop(), reinterpret_cast<uv_pipe_t*>(m_input), 0);
+        r = uv_pipe_open(reinterpret_cast<uv_pipe_t*>(m_input), 0);
+        r = uv_read_start(m_input, Console::onAllocBuffer, Console::onRead);
     }
-
-    uv_tty_set_mode(m_tty, UV_TTY_MODE_RAW);
-    uv_read_start(reinterpret_cast<uv_stream_t*>(m_tty), Console::onAllocBuffer, Console::onRead);
 }
 
 
@@ -46,7 +55,7 @@ xmrig::Console::~Console()
 {
     uv_tty_reset_mode();
 
-    Handle::close(m_tty);
+    Handle::close(m_input);
 }
 
 

--- a/src/base/io/Console.h
+++ b/src/base/io/Console.h
@@ -57,7 +57,7 @@ private:
 
     char m_buf[1] = { 0 };
     IConsoleListener *m_listener;
-    uv_tty_t *m_tty = nullptr;
+    uv_stream_t *m_input = nullptr;
 };
 
 


### PR DESCRIPTION
Hi I recently tried to start and control xmrig from another process but this didn't work, as you connect directly to the TTY.

I added a fallback option to a regular pipe in case the TTY is not available so I can send the `h, c, p, r, s` commands (which of course only work in case you flush the output to the stdin pipe every time you write a character).