### PR TITLE
Added Userspace MSR permissions clarification in CPU.md

### DIFF
--- a/doc/CPU.md
+++ b/doc/CPU.md
@@ -91,11 +91,11 @@ RandomX mining mode: `auto`, `fast` (2 GB memory), `light` (256 MB memory).
 #### `1gb-pages`
 Use 1GB hugepages for RandomX dataset (Linux only). Enabled (`true`) or disabled (`false`). It gives 1-3% speedup.
 
+#### `wrmsr`
+[MSR mod](https://xmrig.com/docs/miner/randomx-optimization-guide/msr). Enabled (`true`) or disabled (`false`). It gives up to 15% speedup depending on your system. _(**Note**: Userspace MSR writes are no longer enabled by default; the flag `msr.allow_writes=on` must be set for Linux Kernels 5.9 and after.)_
+
 #### `rdmsr`
 Restore MSR register values to their original values on exit. Used together with `wrmsr`. Enabled (`true`) or disabled (`false`).
-
-#### `wrmsr`
-[MSR mod](https://xmrig.com/docs/miner/randomx-optimization-guide/msr). Enabled (`true`) or disabled (`false`). It gives up to 15% speedup depending on your system.
 
 #### `cache_qos`
 [Cache QoS](https://xmrig.com/docs/miner/randomx-optimization-guide/qos). Enabled (`true`) or disabled (`false`). It's useful when you can't or don't want to mine on all CPU cores to make mining hashrate more stable.


### PR DESCRIPTION
Userspace MSR writes are no longer allowed by default in Linux Kernels starting with 5.9. _(Per this [commit](https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?h=x86/misc&id=a7e1f67ed29f0c339e2aa7483d13b085127566ab) and [explaination](https://www.phoronix.com/scan.php?page=news_item&px=Linux-Filter-Tightening-MSRs).)_

Userspace MSR writes in kernels that are locked down by default can still be enabled if the `msr.allow_writes=on` kernel flag is set. I.e. setting  `GRUB_CMDLINE_LINUX_DEFAULT="msr.allow_writes=on"` in `/etc/default/grub` for most linux distros.