### PR TITLE
Improved DNS subsystem

### DIFF
--- a/src/base/base.cmake
+++ b/src/base/base.cmake
@@ -44,6 +44,7 @@ set(HEADERS_BASE
     src/base/kernel/Platform.h
     src/base/kernel/Process.h
     src/base/net/dns/Dns.h
+    src/base/net/dns/DnsConfig.h
     src/base/net/dns/DnsRecord.h
     src/base/net/dns/DnsRecords.h
     src/base/net/dns/DnsRequest.h
@@ -103,6 +104,7 @@ set(SOURCES_BASE
     src/base/kernel/Platform.cpp
     src/base/kernel/Process.cpp
     src/base/net/dns/Dns.cpp
+    src/base/net/dns/DnsConfig.cpp
     src/base/net/dns/DnsRecord.cpp
     src/base/net/dns/DnsRecords.cpp
     src/base/net/dns/DnsUvBackend.cpp

--- a/src/base/base.cmake
+++ b/src/base/base.cmake
@@ -32,6 +32,7 @@ set(HEADERS_BASE
     src/base/kernel/interfaces/IConfigListener.h
     src/base/kernel/interfaces/IConfigTransform.h
     src/base/kernel/interfaces/IConsoleListener.h
+    src/base/kernel/interfaces/IDnsBackend.h
     src/base/kernel/interfaces/IDnsListener.h
     src/base/kernel/interfaces/ILineListener.h
     src/base/kernel/interfaces/ILogBackend.h
@@ -45,6 +46,8 @@ set(HEADERS_BASE
     src/base/net/dns/Dns.h
     src/base/net/dns/DnsRecord.h
     src/base/net/dns/DnsRecords.h
+    src/base/net/dns/DnsRequest.h
+    src/base/net/dns/DnsUvBackend.h
     src/base/net/http/Http.h
     src/base/net/http/HttpListener.h
     src/base/net/stratum/BaseClient.h
@@ -102,6 +105,7 @@ set(SOURCES_BASE
     src/base/net/dns/Dns.cpp
     src/base/net/dns/DnsRecord.cpp
     src/base/net/dns/DnsRecords.cpp
+    src/base/net/dns/DnsUvBackend.cpp
     src/base/net/http/Http.cpp
     src/base/net/stratum/BaseClient.cpp
     src/base/net/stratum/Client.cpp

--- a/src/base/base.cmake
+++ b/src/base/base.cmake
@@ -44,6 +44,7 @@ set(HEADERS_BASE
     src/base/kernel/Process.h
     src/base/net/dns/Dns.h
     src/base/net/dns/DnsRecord.h
+    src/base/net/dns/DnsRecords.h
     src/base/net/http/Http.h
     src/base/net/http/HttpListener.h
     src/base/net/stratum/BaseClient.h
@@ -100,6 +101,7 @@ set(SOURCES_BASE
     src/base/kernel/Process.cpp
     src/base/net/dns/Dns.cpp
     src/base/net/dns/DnsRecord.cpp
+    src/base/net/dns/DnsRecords.cpp
     src/base/net/http/Http.cpp
     src/base/net/stratum/BaseClient.cpp
     src/base/net/stratum/Client.cpp

--- a/src/base/kernel/config/BaseConfig.cpp
+++ b/src/base/kernel/config/BaseConfig.cpp
@@ -23,6 +23,7 @@
 #include "base/io/log/Log.h"
 #include "base/io/log/Tags.h"
 #include "base/kernel/interfaces/IJsonReader.h"
+#include "base/net/dns/Dns.h"
 #include "version.h"
 
 
@@ -104,6 +105,8 @@ bool xmrig::BaseConfig::read(const IJsonReader &reader, const char *fileName)
 
     m_http.load(reader.getObject(kHttp));
     m_pools.load(reader);
+
+    Dns::set(reader.getObject(DnsConfig::kField));
 
     return m_pools.active() > 0;
 }

--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -33,6 +33,7 @@
 #include "base/kernel/config/BaseConfig.h"
 #include "base/kernel/interfaces/IConfig.h"
 #include "base/kernel/Process.h"
+#include "base/net/dns/DnsConfig.h"
 #include "base/net/stratum/Pool.h"
 #include "base/net/stratum/Pools.h"
 #include "core/config/Config_platform.h"
@@ -244,6 +245,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::HttpPort:       /* --http-port */
     case IConfig::DonateLevelKey: /* --donate-level */
     case IConfig::DaemonPollKey:  /* --daemon-poll-interval */
+    case IConfig::DnsTtlKey:      /* --dns-ttl */
         return transformUint64(doc, key, static_cast<uint64_t>(strtol(arg, nullptr, 10)));
 
     case IConfig::BackgroundKey:  /* --background */
@@ -256,6 +258,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::DaemonKey:      /* --daemon */
     case IConfig::SubmitToOriginKey: /* --submit-to-origin */
     case IConfig::VerboseKey:     /* --verbose */
+    case IConfig::DnsIPv6Key:     /* --dns-ipv6 */
         return transformBoolean(doc, key, true);
 
     case IConfig::ColorKey:          /* --no-color */
@@ -316,6 +319,9 @@ void xmrig::BaseTransform::transformBoolean(rapidjson::Document &doc, int key, b
     case IConfig::NoTitleKey: /* --no-title */
         return set(doc, BaseConfig::kTitle, enable);
 
+    case IConfig::DnsIPv6Key: /* --dns-ipv6 */
+        return set(doc, DnsConfig::kField, DnsConfig::kIPv6, enable);
+
     default:
         break;
     }
@@ -343,6 +349,9 @@ void xmrig::BaseTransform::transformUint64(rapidjson::Document &doc, int key, ui
 
     case IConfig::PrintTimeKey: /* --print-time */
         return set(doc, BaseConfig::kPrintTime, arg);
+
+    case IConfig::DnsTtlKey: /* --dns-ttl */
+        return set(doc, DnsConfig::kField, DnsConfig::kTTL, arg);
 
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonPollKey:  /* --daemon-poll-interval */

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -82,6 +82,8 @@ public:
         HugePageSizeKey      = 1050,
         PauseOnActiveKey     = 1051,
         SubmitToOriginKey    = 1052,
+        DnsIPv6Key           = 1053,
+        DnsTtlKey            = 1054,
 
         // xmrig common
         CPUPriorityKey       = 1021,

--- a/src/base/kernel/interfaces/IDnsBackend.h
+++ b/src/base/kernel/interfaces/IDnsBackend.h
@@ -16,36 +16,39 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNS_H
-#define XMRIG_DNS_H
+#ifndef XMRIG_IDNSBACKEND_H
+#define XMRIG_IDNSBACKEND_H
 
 
-#include "base/tools/String.h"
+#include "base/tools/Object.h"
 
 
-#include <map>
 #include <memory>
 
 
 namespace xmrig {
 
 
+class DnsRecords;
 class DnsRequest;
-class IDnsBackend;
 class IDnsListener;
+class String;
 
 
-class Dns
+class IDnsBackend
 {
 public:
-    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl = 60000);
+    XMRIG_DISABLE_COPY_MOVE(IDnsBackend)
 
-private:
-    static std::map<String, std::shared_ptr<IDnsBackend> > m_backends;
+    IDnsBackend()           = default;
+    virtual ~IDnsBackend()  = default;
+
+    virtual const DnsRecords &records() const                                                               = 0;
+    virtual std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl)   = 0;
 };
 
 
 } /* namespace xmrig */
 
 
-#endif /* XMRIG_DNS_H */
+#endif // XMRIG_IDNSBACKEND_H

--- a/src/base/kernel/interfaces/IDnsListener.h
+++ b/src/base/kernel/interfaces/IDnsListener.h
@@ -37,7 +37,7 @@ public:
     IDnsListener()          = default;
     virtual ~IDnsListener() = default;
 
-    virtual void onResolved(const DnsRecords &records, int status) = 0;
+    virtual void onResolved(const DnsRecords &records, int status, const char *error)   = 0;
 };
 
 

--- a/src/base/net/dns/Dns.cpp
+++ b/src/base/net/dns/Dns.cpp
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -23,7 +23,6 @@
 
 namespace xmrig {
     Storage<Dns> Dns::m_storage;
-    static const DnsRecord defaultRecord;
 }
 
 
@@ -54,7 +53,7 @@ bool xmrig::Dns::resolve(const String &host)
     if (m_host != host) {
         m_host = host;
 
-        clear();
+        m_records.clear();
     }
 
     m_status = uv_getaddrinfo(uv_default_loop(), m_resolver, Dns::onResolved, m_host.data(), nullptr, &m_hints);
@@ -63,82 +62,21 @@ bool xmrig::Dns::resolve(const String &host)
 }
 
 
-const char *xmrig::Dns::error() const
-{
-    return uv_strerror(m_status);
-}
-
-
-const xmrig::DnsRecord &xmrig::Dns::get(DnsRecord::Type prefered) const
-{
-    if (count() == 0) {
-        return defaultRecord;
-    }
-
-    const size_t ipv4 = m_ipv4.size();
-    const size_t ipv6 = m_ipv6.size();
-
-    if (ipv6 && (prefered == DnsRecord::AAAA || !ipv4)) {
-        return m_ipv6[ipv6 == 1 ? 0 : static_cast<size_t>(rand()) % ipv6];
-    }
-
-    if (ipv4) {
-        return m_ipv4[ipv4 == 1 ? 0 : static_cast<size_t>(rand()) % ipv4];
-    }
-
-    return defaultRecord;
-}
-
-
-size_t xmrig::Dns::count(DnsRecord::Type type) const
-{
-    if (type == DnsRecord::A) {
-        return m_ipv4.size();
-    }
-
-    if (type == DnsRecord::AAAA) {
-        return m_ipv6.size();
-    }
-
-    return m_ipv4.size() + m_ipv6.size();
-}
-
-
-void xmrig::Dns::clear()
-{
-    m_ipv4.clear();
-    m_ipv6.clear();
-}
-
-
 void xmrig::Dns::onResolved(int status, addrinfo *res)
 {
     m_status = status;
 
     if (m_status < 0) {
-        return m_listener->onResolved(*this, status);
+        return m_listener->onResolved(m_records, status);
     }
 
-    clear();
+    m_records.parse(res);
 
-    addrinfo *ptr = res;
-    while (ptr != nullptr) {
-        if (ptr->ai_family == AF_INET) {
-            m_ipv4.emplace_back(ptr);
-        }
-
-        if (ptr->ai_family == AF_INET6) {
-            m_ipv6.emplace_back(ptr);
-        }
-
-        ptr = ptr->ai_next;
-    }
-
-    if (isEmpty()) {
+    if (m_records.isEmpty()) {
         m_status = UV_EAI_NONAME;
     }
 
-    m_listener->onResolved(*this, m_status);
+    m_listener->onResolved(m_records, m_status);
 }
 
 

--- a/src/base/net/dns/Dns.h
+++ b/src/base/net/dns/Dns.h
@@ -20,6 +20,7 @@
 #define XMRIG_DNS_H
 
 
+#include "base/net/dns/DnsConfig.h"
 #include "base/tools/String.h"
 
 
@@ -30,6 +31,7 @@
 namespace xmrig {
 
 
+class DnsConfig;
 class DnsRequest;
 class IDnsBackend;
 class IDnsListener;
@@ -38,9 +40,13 @@ class IDnsListener;
 class Dns
 {
 public:
-    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl = 60000);
+    inline static const DnsConfig &config()             { return m_config; }
+    inline static void set(const DnsConfig &config)     { m_config = config; }
+
+    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl = 0);
 
 private:
+    static DnsConfig m_config;
     static std::map<String, std::shared_ptr<IDnsBackend> > m_backends;
 };
 

--- a/src/base/net/dns/Dns.h
+++ b/src/base/net/dns/Dns.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -24,10 +24,9 @@
 #include <uv.h>
 
 
-#include "base/net/dns/DnsRecord.h"
+#include "base/net/dns/DnsRecords.h"
 #include "base/net/tools/Storage.h"
 #include "base/tools/Object.h"
-#include "base/tools/String.h"
 
 
 namespace xmrig {
@@ -44,26 +43,20 @@ public:
     Dns(IDnsListener *listener);
     ~Dns();
 
-    inline bool isEmpty() const       { return m_ipv4.empty() && m_ipv6.empty(); }
     inline const String &host() const { return m_host; }
     inline int status() const         { return m_status; }
 
     bool resolve(const String &host);
-    const char *error() const;
-    const DnsRecord &get(DnsRecord::Type prefered = DnsRecord::A) const;
-    size_t count(DnsRecord::Type type = DnsRecord::Unknown) const;
 
 private:
-    void clear();
     void onResolved(int status, addrinfo *res);
 
     static void onResolved(uv_getaddrinfo_t *req, int status, addrinfo *res);
 
     addrinfo m_hints{};
+    DnsRecords m_records;
     IDnsListener *m_listener;
     int m_status                    = 0;
-    std::vector<DnsRecord> m_ipv4;
-    std::vector<DnsRecord> m_ipv6;
     String m_host;
     uintptr_t m_key;
     uv_getaddrinfo_t *m_resolver    = nullptr;

--- a/src/base/net/dns/DnsConfig.h
+++ b/src/base/net/dns/DnsConfig.h
@@ -16,26 +16,39 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef XMRIG_DNSCONFIG_H
+#define XMRIG_DNSCONFIG_H
 
-#include "base/net/dns/Dns.h"
-#include "base/net/dns/DnsUvBackend.h"
+
+#include "3rdparty/rapidjson/fwd.h"
 
 
 namespace xmrig {
 
 
-DnsConfig Dns::m_config;
-std::map<String, std::shared_ptr<IDnsBackend> > Dns::m_backends;
-
-
-} // namespace xmrig
-
-
-std::shared_ptr<xmrig::DnsRequest> xmrig::Dns::resolve(const String &host, IDnsListener *listener, uint64_t ttl)
+class DnsConfig
 {
-    if (m_backends.find(host) == m_backends.end()) {
-        m_backends.insert({ host, std::make_shared<DnsUvBackend>() });
-    }
+public:
+    static const char *kField;
+    static const char *kIPv6;
+    static const char *kTTL;
 
-    return m_backends.at(host)->resolve(host, listener, ttl == 0 ? m_config.ttl() : ttl);
-}
+    DnsConfig() = default;
+    DnsConfig(const rapidjson::Value &object);
+
+    inline bool isIPv6() const  { return m_ipv6; }
+    inline uint32_t ttl() const { return m_ttl * 1000U; }
+
+    rapidjson::Value toJSON(rapidjson::Document &doc) const;
+
+
+private:
+    bool m_ipv6     = false;
+    uint32_t m_ttl  = 30U;
+};
+
+
+} /* namespace xmrig */
+
+
+#endif /* XMRIG_DNSCONFIG_H */

--- a/src/base/net/dns/DnsRecord.h
+++ b/src/base/net/dns/DnsRecord.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2020 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2020 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ namespace xmrig {
 class DnsRecord
 {
 public:
-    enum Type {
+    enum Type : uint32_t {
         Unknown,
         A,
         AAAA
@@ -42,15 +42,15 @@ public:
     DnsRecord() {}
     DnsRecord(const addrinfo *addr);
 
-    sockaddr *addr(uint16_t port = 0) const;
+    const sockaddr *addr(uint16_t port = 0) const;
+    String ip() const;
 
     inline bool isValid() const     { return m_type != Unknown; }
-    inline const String &ip() const { return m_ip; }
     inline Type type() const        { return m_type; }
 
 private:
-    Type m_type = Unknown;
-    String m_ip;
+    mutable uint8_t m_data[28]{};
+    const Type m_type = Unknown;
 };
 
 

--- a/src/base/net/dns/DnsRecords.cpp
+++ b/src/base/net/dns/DnsRecords.cpp
@@ -1,0 +1,107 @@
+/* XMRig
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <uv.h>
+
+
+#include "base/net/dns/DnsRecords.h"
+
+
+const xmrig::DnsRecord &xmrig::DnsRecords::get(DnsRecord::Type prefered) const
+{
+    static const DnsRecord defaultRecord;
+
+    if (isEmpty()) {
+        return defaultRecord;
+    }
+
+    const size_t ipv4 = m_ipv4.size();
+    const size_t ipv6 = m_ipv6.size();
+
+    if (ipv6 && (prefered == DnsRecord::AAAA || !ipv4)) {
+        return m_ipv6[ipv6 == 1 ? 0 : static_cast<size_t>(rand()) % ipv6];
+    }
+
+    if (ipv4) {
+        return m_ipv4[ipv4 == 1 ? 0 : static_cast<size_t>(rand()) % ipv4];
+    }
+
+    return defaultRecord;
+}
+
+
+size_t xmrig::DnsRecords::count(DnsRecord::Type type) const
+{
+    if (type == DnsRecord::A) {
+        return m_ipv4.size();
+    }
+
+    if (type == DnsRecord::AAAA) {
+        return m_ipv6.size();
+    }
+
+    return m_ipv4.size() + m_ipv6.size();
+}
+
+
+void xmrig::DnsRecords::clear()
+{
+    m_ipv4.clear();
+    m_ipv6.clear();
+}
+
+
+void xmrig::DnsRecords::parse(addrinfo *res)
+{
+    clear();
+
+    addrinfo *ptr = res;
+    size_t ipv4   = 0;
+    size_t ipv6   = 0;
+
+    while (ptr != nullptr) {
+        if (ptr->ai_family == AF_INET) {
+            ++ipv4;
+        }
+        else if (ptr->ai_family == AF_INET6) {
+            ++ipv6;
+        }
+
+        ptr = ptr->ai_next;
+    }
+
+    if (ipv4 == 0 && ipv6 == 0) {
+        return;
+    }
+
+    m_ipv4.reserve(ipv4);
+    m_ipv6.reserve(ipv6);
+
+    ptr = res;
+    while (ptr != nullptr) {
+        if (ptr->ai_family == AF_INET) {
+            m_ipv4.emplace_back(ptr);
+        }
+        else if (ptr->ai_family == AF_INET6) {
+            m_ipv6.emplace_back(ptr);
+        }
+
+        ptr = ptr->ai_next;
+    }
+}

--- a/src/base/net/dns/DnsRecords.cpp
+++ b/src/base/net/dns/DnsRecords.cpp
@@ -21,6 +21,7 @@
 
 
 #include "base/net/dns/DnsRecords.h"
+#include "base/net/dns/Dns.h"
 
 
 const xmrig::DnsRecord &xmrig::DnsRecords::get(DnsRecord::Type prefered) const
@@ -34,7 +35,7 @@ const xmrig::DnsRecord &xmrig::DnsRecords::get(DnsRecord::Type prefered) const
     const size_t ipv4 = m_ipv4.size();
     const size_t ipv6 = m_ipv6.size();
 
-    if (ipv6 && (prefered == DnsRecord::AAAA || !ipv4)) {
+    if (ipv6 && (prefered == DnsRecord::AAAA || Dns::config().isIPv6() || !ipv4)) {
         return m_ipv6[ipv6 == 1 ? 0 : static_cast<size_t>(rand()) % ipv6];
     }
 

--- a/src/base/net/dns/DnsRecords.h
+++ b/src/base/net/dns/DnsRecords.h
@@ -31,7 +31,7 @@ class DnsRecords
 public:
     inline bool isEmpty() const       { return m_ipv4.empty() && m_ipv6.empty(); }
 
-    const DnsRecord &get(DnsRecord::Type prefered = DnsRecord::A) const;
+    const DnsRecord &get(DnsRecord::Type prefered = DnsRecord::Unknown) const;
     size_t count(DnsRecord::Type type = DnsRecord::Unknown) const;
     void clear();
     void parse(addrinfo *res);

--- a/src/base/net/dns/DnsRecords.h
+++ b/src/base/net/dns/DnsRecords.h
@@ -16,32 +16,33 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_IDNSLISTENER_H
-#define XMRIG_IDNSLISTENER_H
+#ifndef XMRIG_DNSRECORDS_H
+#define XMRIG_DNSRECORDS_H
 
 
-#include "base/tools/Object.h"
+#include "base/net/dns/DnsRecord.h"
 
 
 namespace xmrig {
 
 
-class DnsRecords;
-
-
-class IDnsListener
+class DnsRecords
 {
 public:
-    XMRIG_DISABLE_COPY_MOVE(IDnsListener)
+    inline bool isEmpty() const       { return m_ipv4.empty() && m_ipv6.empty(); }
 
-    IDnsListener()          = default;
-    virtual ~IDnsListener() = default;
+    const DnsRecord &get(DnsRecord::Type prefered = DnsRecord::A) const;
+    size_t count(DnsRecord::Type type = DnsRecord::Unknown) const;
+    void clear();
+    void parse(addrinfo *res);
 
-    virtual void onResolved(const DnsRecords &records, int status) = 0;
+private:
+    std::vector<DnsRecord> m_ipv4;
+    std::vector<DnsRecord> m_ipv6;
 };
 
 
 } /* namespace xmrig */
 
 
-#endif // XMRIG_IDNSLISTENER_H
+#endif /* XMRIG_DNSRECORDS_H */

--- a/src/base/net/dns/DnsRequest.h
+++ b/src/base/net/dns/DnsRequest.h
@@ -16,36 +16,35 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNS_H
-#define XMRIG_DNS_H
+#ifndef XMRIG_DNSREQUEST_H
+#define XMRIG_DNSREQUEST_H
 
 
-#include "base/tools/String.h"
+#include "base/tools/Object.h"
 
 
-#include <map>
-#include <memory>
+#include <cstdint>
 
 
 namespace xmrig {
 
 
-class DnsRequest;
-class IDnsBackend;
 class IDnsListener;
 
 
-class Dns
+class DnsRequest
 {
 public:
-    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl = 60000);
+    XMRIG_DISABLE_COPY_MOVE_DEFAULT(DnsRequest)
 
-private:
-    static std::map<String, std::shared_ptr<IDnsBackend> > m_backends;
+    DnsRequest(IDnsListener *listener) : listener(listener) {}
+    ~DnsRequest() = default;
+
+    IDnsListener *listener;
 };
 
 
 } /* namespace xmrig */
 
 
-#endif /* XMRIG_DNS_H */
+#endif /* XMRIG_DNSREQUEST_H */

--- a/src/base/net/dns/DnsUvBackend.cpp
+++ b/src/base/net/dns/DnsUvBackend.cpp
@@ -1,0 +1,130 @@
+/* XMRig
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <uv.h>
+
+
+#include "base/net/dns/DnsUvBackend.h"
+#include "base/kernel/interfaces/IDnsListener.h"
+#include "base/net/dns/DnsRequest.h"
+#include "base/tools/Chrono.h"
+
+
+namespace xmrig {
+
+
+Storage<DnsUvBackend> DnsUvBackend::m_storage;
+
+static addrinfo hints{};
+
+
+} // namespace xmrig
+
+
+xmrig::DnsUvBackend::DnsUvBackend()
+{
+    if (!hints.ai_protocol) {
+        hints.ai_family     = AF_UNSPEC;
+        hints.ai_socktype   = SOCK_STREAM;
+        hints.ai_protocol   = IPPROTO_TCP;
+    }
+
+    m_key = m_storage.add(this);
+}
+
+
+xmrig::DnsUvBackend::~DnsUvBackend()
+{
+    m_storage.release(m_key);
+}
+
+
+std::shared_ptr<xmrig::DnsRequest> xmrig::DnsUvBackend::resolve(const String &host, IDnsListener *listener, uint64_t ttl)
+{
+    auto req = std::make_shared<DnsRequest>(listener);
+
+    if (Chrono::currentMSecsSinceEpoch() - m_ts <= ttl && !m_records.isEmpty()) {
+        req->listener->onResolved(m_records, 0, nullptr);
+    } else {
+        m_queue.emplace(req);
+    }
+
+    if (m_queue.size() == 1 && !resolve(host)) {
+        done();
+    }
+
+    return req;
+}
+
+
+bool xmrig::DnsUvBackend::resolve(const String &host)
+{
+    m_req = std::make_shared<uv_getaddrinfo_t>();
+    m_req->data = m_storage.ptr(m_key);
+
+    m_status = uv_getaddrinfo(uv_default_loop(), m_req.get(), DnsUvBackend::onResolved, host.data(), nullptr, &hints);
+
+    return m_status == 0;
+}
+
+
+void xmrig::DnsUvBackend::done()
+{
+    const char *error = m_status < 0 ? uv_strerror(m_status) : nullptr;
+
+    while (!m_queue.empty()) {
+        auto req = std::move(m_queue.front()).lock();
+        if (req) {
+            req->listener->onResolved(m_records, m_status, error);
+        }
+
+        m_queue.pop();
+    }
+
+    m_req.reset();
+}
+
+
+void xmrig::DnsUvBackend::onResolved(int status, addrinfo *res)
+{
+    m_ts = Chrono::currentMSecsSinceEpoch();
+
+    if ((m_status = status) < 0) {
+        return done();
+    }
+
+    m_records.parse(res);
+
+    if (m_records.isEmpty()) {
+        m_status = UV_EAI_NONAME;
+    }
+
+    done();
+}
+
+
+void xmrig::DnsUvBackend::onResolved(uv_getaddrinfo_t *req, int status, addrinfo *res)
+{
+    auto backend = m_storage.get(req->data);
+    if (backend) {
+        backend->onResolved(status, res);
+    }
+
+    uv_freeaddrinfo(res);
+}

--- a/src/base/net/dns/DnsUvBackend.h
+++ b/src/base/net/dns/DnsUvBackend.h
@@ -1,0 +1,71 @@
+/* XMRig
+ * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XMRIG_DNSUVBACKEND_H
+#define XMRIG_DNSUVBACKEND_H
+
+
+#include "base/kernel/interfaces/IDnsBackend.h"
+#include "base/net/dns/DnsRecords.h"
+#include "base/net/tools/Storage.h"
+
+
+#include <queue>
+
+
+using uv_getaddrinfo_t = struct uv_getaddrinfo_s;
+
+
+namespace xmrig {
+
+
+class DnsUvBackend : public IDnsBackend
+{
+public:
+    XMRIG_DISABLE_COPY_MOVE(DnsUvBackend)
+
+    DnsUvBackend();
+    ~DnsUvBackend() override;
+
+protected:
+    inline const DnsRecords &records() const override   { return m_records; }
+
+    std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl) override;
+
+private:
+    bool resolve(const String &host);
+    void done();
+    void onResolved(int status, addrinfo *res);
+
+    static void onResolved(uv_getaddrinfo_t *req, int status, addrinfo *res);
+
+    DnsRecords m_records;
+    int m_status            = 0;
+    std::queue<std::weak_ptr<DnsRequest> > m_queue;
+    std::shared_ptr<uv_getaddrinfo_t> m_req;
+    uint64_t m_ts           = 0;
+    uintptr_t m_key;
+
+    static Storage<DnsUvBackend> m_storage;
+};
+
+
+} /* namespace xmrig */
+
+
+#endif /* XMRIG_DNSUVBACKEND_H */

--- a/src/base/net/http/HttpClient.cpp
+++ b/src/base/net/http/HttpClient.cpp
@@ -23,11 +23,13 @@
 #include "base/io/log/Log.h"
 #include "base/kernel/Platform.h"
 #include "base/net/dns/Dns.h"
+#include "base/net/dns/DnsRecords.h"
 #include "base/net/tools/NetBuffer.h"
 #include "base/tools/Timer.h"
 
 
 #include <sstream>
+#include <uv.h>
 
 
 namespace xmrig {
@@ -48,7 +50,6 @@ xmrig::HttpClient::HttpClient(const char *tag, FetchRequest &&req, const std::we
     url     = std::move(m_req.path);
     body    = std::move(m_req.body);
     headers = std::move(m_req.headers);
-    m_dns   = std::make_shared<Dns>(this);
 
     if (m_req.timeout) {
         m_timer = std::make_shared<Timer>(this, m_req.timeout, 0);
@@ -58,17 +59,20 @@ xmrig::HttpClient::HttpClient(const char *tag, FetchRequest &&req, const std::we
 
 bool xmrig::HttpClient::connect()
 {
-    return m_dns->resolve(m_req.host);
+    m_dns = Dns::resolve(m_req.host, this);
+
+    return true;
 }
 
 
-void xmrig::HttpClient::onResolved(const DnsRecords &records, int status)
+void xmrig::HttpClient::onResolved(const DnsRecords &records, int status, const char *error)
 {
     this->status = status;
+    m_dns.reset();
 
     if (status < 0 && records.isEmpty()) {
         if (!isQuiet()) {
-            LOG_ERR("%s " RED("DNS error: ") RED_BOLD("\"%s\""), tag(), uv_strerror(status));
+            LOG_ERR("%s " RED("DNS error: ") RED_BOLD("\"%s\""), tag(), error);
         }
 
         return;

--- a/src/base/net/http/HttpClient.cpp
+++ b/src/base/net/http/HttpClient.cpp
@@ -62,11 +62,11 @@ bool xmrig::HttpClient::connect()
 }
 
 
-void xmrig::HttpClient::onResolved(const Dns &dns, int status)
+void xmrig::HttpClient::onResolved(const DnsRecords &records, int status)
 {
     this->status = status;
 
-    if (status < 0 && dns.isEmpty()) {
+    if (status < 0 && records.isEmpty()) {
         if (!isQuiet()) {
             LOG_ERR("%s " RED("DNS error: ") RED_BOLD("\"%s\""), tag(), uv_strerror(status));
         }
@@ -77,7 +77,7 @@ void xmrig::HttpClient::onResolved(const Dns &dns, int status)
     auto req  = new uv_connect_t;
     req->data = this;
 
-    uv_tcp_connect(req, m_tcp, dns.get().addr(port()), onConnect);
+    uv_tcp_connect(req, m_tcp, records.get().addr(port()), onConnect);
 }
 
 

--- a/src/base/net/http/HttpClient.cpp
+++ b/src/base/net/http/HttpClient.cpp
@@ -74,14 +74,10 @@ void xmrig::HttpClient::onResolved(const Dns &dns, int status)
         return;
     }
 
-    sockaddr *addr = dns.get().addr(port());
-
     auto req  = new uv_connect_t;
     req->data = this;
 
-    uv_tcp_connect(req, m_tcp, addr, onConnect);
-
-    delete addr;
+    uv_tcp_connect(req, m_tcp, dns.get().addr(port()), onConnect);
 }
 
 

--- a/src/base/net/http/HttpClient.h
+++ b/src/base/net/http/HttpClient.h
@@ -32,7 +32,7 @@
 namespace xmrig {
 
 
-class Dns;
+class DnsRequest;
 
 
 class HttpClient : public HttpContext, public IDnsListener, public ITimerListener
@@ -51,7 +51,7 @@ public:
     bool connect();
 
 protected:
-    void onResolved(const DnsRecords &records, int status) override;
+    void onResolved(const DnsRecords &records, int status, const char *error) override;
     void onTimer(const Timer *timer) override;
 
     virtual void handshake();
@@ -65,7 +65,7 @@ private:
 
     const char *m_tag;
     FetchRequest m_req;
-    std::shared_ptr<Dns> m_dns;
+    std::shared_ptr<DnsRequest> m_dns;
     std::shared_ptr<Timer> m_timer;
 };
 

--- a/src/base/net/http/HttpClient.h
+++ b/src/base/net/http/HttpClient.h
@@ -32,7 +32,7 @@
 namespace xmrig {
 
 
-class String;
+class Dns;
 
 
 class HttpClient : public HttpContext, public IDnsListener, public ITimerListener
@@ -51,7 +51,7 @@ public:
     bool connect();
 
 protected:
-    void onResolved(const Dns &dns, int status) override;
+    void onResolved(const DnsRecords &records, int status) override;
     void onTimer(const Timer *timer) override;
 
     virtual void handshake();

--- a/src/base/net/stratum/Client.cpp
+++ b/src/base/net/stratum/Client.cpp
@@ -566,7 +566,7 @@ int64_t xmrig::Client::send(size_t size)
 }
 
 
-void xmrig::Client::connect(sockaddr *addr)
+void xmrig::Client::connect(const sockaddr *addr)
 {
     setState(ConnectingState);
 
@@ -584,8 +584,6 @@ void xmrig::Client::connect(sockaddr *addr)
 #   endif
 
     uv_tcp_connect(req, m_socket, addr, onConnect);
-
-    delete addr;
 }
 
 

--- a/src/base/net/stratum/Client.cpp
+++ b/src/base/net/stratum/Client.cpp
@@ -295,14 +295,14 @@ void xmrig::Client::tick(uint64_t now)
 }
 
 
-void xmrig::Client::onResolved(const Dns &dns, int status)
+void xmrig::Client::onResolved(const DnsRecords &records, int status)
 {
     assert(m_listener != nullptr);
     if (!m_listener) {
         return reconnect();
     }
 
-    if (status < 0 && dns.isEmpty()) {
+    if (status < 0 && records.isEmpty()) {
         if (!isQuiet()) {
             LOG_ERR("%s " RED("DNS error: ") RED_BOLD("\"%s\""), tag(), uv_strerror(status));
         }
@@ -310,7 +310,7 @@ void xmrig::Client::onResolved(const Dns &dns, int status)
         return reconnect();
     }
 
-    const auto &record = dns.get();
+    const auto &record = records.get();
     m_ip = record.ip();
 
     connect(record.addr(m_socks5 ? m_pool.proxy().port() : m_pool.port()));

--- a/src/base/net/stratum/Client.h
+++ b/src/base/net/stratum/Client.h
@@ -50,6 +50,7 @@ using BIO = struct bio_st;
 namespace xmrig {
 
 
+class Dns;
 class IClientListener;
 class JobResult;
 
@@ -79,7 +80,7 @@ protected:
     void deleteLater() override;
     void tick(uint64_t now) override;
 
-    void onResolved(const Dns &dns, int status) override;
+    void onResolved(const DnsRecords &records, int status) override;
 
     inline bool hasExtension(Extension extension) const noexcept override   { return m_extensions.test(extension); }
     inline const char *mode() const override                                { return "pool"; }

--- a/src/base/net/stratum/Client.h
+++ b/src/base/net/stratum/Client.h
@@ -50,7 +50,7 @@ using BIO = struct bio_st;
 namespace xmrig {
 
 
-class Dns;
+class DnsRequest;
 class IClientListener;
 class JobResult;
 
@@ -80,7 +80,7 @@ protected:
     void deleteLater() override;
     void tick(uint64_t now) override;
 
-    void onResolved(const DnsRecords &records, int status) override;
+    void onResolved(const DnsRecords &records, int status, const char *error) override;
 
     inline bool hasExtension(Extension extension) const noexcept override   { return m_extensions.test(extension); }
     inline const char *mode() const override                                { return "pool"; }
@@ -132,10 +132,10 @@ private:
     static inline Client *getClient(void *data) { return m_storage.get(data); }
 
     const char *m_agent;
-    Dns *m_dns;
     LineReader m_reader;
     Socks5 *m_socks5            = nullptr;
     std::bitset<EXT_MAX> m_extensions;
+    std::shared_ptr<DnsRequest> m_dns;
     std::vector<char> m_sendBuf;
     String m_rpcId;
     Tls *m_tls                  = nullptr;

--- a/src/base/net/stratum/Client.h
+++ b/src/base/net/stratum/Client.h
@@ -108,7 +108,7 @@ private:
     bool write(const uv_buf_t &buf);
     int resolve(const String &host);
     int64_t send(size_t size);
-    void connect(sockaddr *addr);
+    void connect(const sockaddr *addr);
     void handshake();
     void parse(char *line, size_t len);
     void parseExtensions(const rapidjson::Value &result);

--- a/src/base/net/stratum/benchmark/BenchClient.cpp
+++ b/src/base/net/stratum/benchmark/BenchClient.cpp
@@ -185,16 +185,16 @@ void xmrig::BenchClient::onHttpData(const HttpData &data)
 }
 
 
-void xmrig::BenchClient::onResolved(const Dns &dns, int status)
+void xmrig::BenchClient::onResolved(const DnsRecords &records, int status)
 {
 #   ifdef XMRIG_FEATURE_HTTP
     assert(!m_httpListener);
 
     if (status < 0) {
-        return setError(dns.error(), "DNS error");
+        return setError(uv_strerror(status), "DNS error");
     }
 
-    m_ip            = dns.get().ip();
+    m_ip            = records.get().ip();
     m_httpListener  = std::make_shared<HttpListener>(this, tag());
 
     if (m_mode == ONLINE_BENCH) {
@@ -310,7 +310,7 @@ void xmrig::BenchClient::resolve()
     m_dns = std::make_shared<Dns>(this);
 
     if (!m_dns->resolve(BenchConfig::kApiHost)) {
-        setError(m_dns->error(), "getaddrinfo error");
+        setError(uv_strerror(m_dns->status()), "getaddrinfo error");
     }
 }
 

--- a/src/base/net/stratum/benchmark/BenchClient.h
+++ b/src/base/net/stratum/benchmark/BenchClient.h
@@ -70,7 +70,7 @@ protected:
     void onBenchDone(uint64_t result, uint64_t diff, uint64_t ts) override;
     void onBenchReady(uint64_t ts, uint32_t threads, const IBackend *backend) override;
     void onHttpData(const HttpData &data) override;
-    void onResolved(const DnsRecords &records, int status) override;
+    void onResolved(const DnsRecords &records, int status, const char *error) override;
 
 private:
     enum Mode : uint32_t {
@@ -110,7 +110,7 @@ private:
     Pool m_pool;
     Request m_request           = NO_REQUEST;
     std::shared_ptr<BenchConfig> m_benchmark;
-    std::shared_ptr<Dns> m_dns;
+    std::shared_ptr<DnsRequest> m_dns;
     std::shared_ptr<IHttpListener> m_httpListener;
     String m_ip;
     String m_token;

--- a/src/base/net/stratum/benchmark/BenchClient.h
+++ b/src/base/net/stratum/benchmark/BenchClient.h
@@ -70,7 +70,7 @@ protected:
     void onBenchDone(uint64_t result, uint64_t diff, uint64_t ts) override;
     void onBenchReady(uint64_t ts, uint32_t threads, const IBackend *backend) override;
     void onHttpData(const HttpData &data) override;
-    void onResolved(const Dns &dns, int status) override;
+    void onResolved(const DnsRecords &records, int status) override;
 
 private:
     enum Mode : uint32_t {

--- a/src/core/config/Config.cpp
+++ b/src/core/config/Config.cpp
@@ -28,6 +28,7 @@
 #include "backend/cpu/Cpu.h"
 #include "base/io/log/Log.h"
 #include "base/kernel/interfaces/IJsonReader.h"
+#include "base/net/dns/Dns.h"
 #include "crypto/common/Assembly.h"
 
 
@@ -295,6 +296,7 @@ void xmrig::Config::getJSON(rapidjson::Document &doc) const
     doc.AddMember(StringRef(kTls),                      m_tls.toJSON(doc), allocator);
 #   endif
 
+    doc.AddMember(StringRef(DnsConfig::kField),         Dns::config().toJSON(doc), allocator);
     doc.AddMember(StringRef(kUserAgent),                m_userAgent.toJSON(), allocator);
     doc.AddMember(StringRef(kVerbose),                  Log::verbose(), allocator);
     doc.AddMember(StringRef(kWatch),                    m_watch, allocator);

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -93,7 +93,9 @@ static const option options[] = {
     { "title",                 1, nullptr, IConfig::TitleKey              },
     { "no-title",              0, nullptr, IConfig::NoTitleKey            },
     { "pause-on-battery",      0, nullptr, IConfig::PauseOnBatteryKey     },
-    { "pause-on-active",       1, nullptr, IConfig::PauseOnActiveKey     },
+    { "pause-on-active",       1, nullptr, IConfig::PauseOnActiveKey      },
+    { "dns-ipv6",              0, nullptr, IConfig::DnsIPv6Key            },
+    { "dns-ttl",               1, nullptr, IConfig::DnsTtlKey             },
 #   ifdef XMRIG_FEATURE_BENCHMARK
     { "stress",                0, nullptr, IConfig::StressKey             },
     { "bench",                 1, nullptr, IConfig::BenchKey              },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -59,6 +59,9 @@ static inline const std::string &usage()
     u += "      --tls-fingerprint=HEX     pool TLS certificate fingerprint for strict certificate pinning\n";
 #   endif
 
+    u += "      --dns-ipv6                prefer IPv6 records from DNS responses\n";
+    u += "      --dns-ttl=N               N seconds (default: 30) TTL for internal DNS cache\n";
+
 #   ifdef XMRIG_FEATURE_HTTP
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";
     u += "      --daemon-poll-interval=N  daemon poll interval in milliseconds (default: 1000)\n";


### PR DESCRIPTION
* Added internal DNS cache with configurable TTL. `"ttl"` in `"dns"` object or `--dns-ipv6`.
* Added a new option to prefer to use IPv6. `"ipv6"` in `"dns"` object or `--dns-ttl=N`.
* General code improvements.
