### PR TITLE
Add LTO/IPO support in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0069 NEW)
+
 project(xmrig)
 
 option(WITH_HWLOC           "Enable hwloc support" ON)
@@ -31,6 +33,7 @@ option(WITH_DMI             "Enable DMI/SMBIOS reader" ON)
 option(BUILD_STATIC         "Build static binary" OFF)
 option(ARM_TARGET           "Force use specific ARM target 8 or 7" 0)
 option(HWLOC_DEBUG          "Enable hwloc debug helpers and log" OFF)
+option(WITH_IPO             "Enable IPO / LTO optimizations" OFF)
 
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
@@ -82,7 +85,7 @@ set(HEADERS_CRYPTO
     src/crypto/cn/skein_port.h
     src/crypto/cn/soft_aes.h
     src/crypto/common/HugePagesInfo.h
-    src/crypto/common/MemoryPool.h
+    src/crypto/common/MemoryPool.hhttps://gcc.gnu.org/onlinedocs/gccint/LTO-Overview.html
     src/crypto/common/Nonce.h
     src/crypto/common/portable/mm_malloc.h
     src/crypto/common/VirtualMemory.h
@@ -168,6 +171,19 @@ else()
         set(EXTRA_LIBS pthread rt dl)
     elseif (XMRIG_OS_FREEBSD)
         set(EXTRA_LIBS kvm pthread)
+    endif()
+endif()
+
+
+if(WITH_IPO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+
+    if( IPO_SUPPORTED )
+        message(STATUS "IPO / LTO enabled")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(STATUS "IPO / LTO not supported: <${IPO_ERROR}>")
     endif()
 endif()
 

--- a/src/3rdparty/argon2/CMakeLists.txt
+++ b/src/3rdparty/argon2/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0069 NEW)
 
 project(argon2 C)
 set(CMAKE_C_STANDARD 99)

--- a/src/3rdparty/hwloc/CMakeLists.txt
+++ b/src/3rdparty/hwloc/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required (VERSION  2.8.12)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0069 NEW)
+
 project (hwloc C)
 
 include_directories(include)

--- a/src/3rdparty/libethash/CMakeLists.txt
+++ b/src/3rdparty/libethash/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(SET CMP0069 NEW)
+
 project (ethash C)
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Os")


### PR DESCRIPTION
| LTO | Results (sudo xmrig --bench=1M) 30% completion |   
| - | -|
| Yes | 10s/60s/15m 2006.0 1982.9 n/a H/s max 2058.7 H/s 
| No | 10s/60s/15m 1915.0 1867.4 n/a H/s max 2030.7 H/s |

```
 * ABOUT        XMRig/6.10.0 gcc/10.2.0
 * LIBS         libuv/1.41.0 OpenSSL/1.1.1k hwloc/2.4.0
 * HUGE PAGES   supported
 * 1GB PAGES    disabled
 * CPU          Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz (1) 64-bit AES
                L2:1.0 MB L3:8.0 MB 4C/4T NUMA:1
 * MEMORY       13.4/31.2 GB (43%)
                DIMM_A0: 16 GB DDR4 @ 2133 MHz CMK32GX4M2B3000C15  
                ChannelA-DIMM1: <empty>
                DIMM_B0: 16 GB DDR4 @ 2133 MHz CT16G4DFD824A.C16FBD
                ChannelB-DIMM1: <empty>
 * MOTHERBOARD  Gigabyte Technology Co., Ltd. - B150M-D3H-CF
```

https://stackoverflow.com/questions/23736507/is-there-a-reason-why-not-to-use-link-time-optimization-lto
https://gcc.gnu.org/onlinedocs/gccint/LTO-Overview.html