### PR TITLE
Add missing include

### DIFF
--- a/src/backend/common/Workers.h
+++ b/src/backend/common/Workers.h
@@ -20,6 +20,9 @@
 #define XMRIG_WORKERS_H
 
 
+#include <memory>
+
+
 #include "backend/common/Thread.h"
 #include "backend/cpu/CpuLaunchData.h"
 


### PR DESCRIPTION
`memory` header ends up not being included when built without OpenCL support.

Closes: https://github.com/xmrig/xmrig/issues/2224