### PR TITLE
remove useless v4_random_math_init if algo is not cn/r

### DIFF
--- a/src/crypto/cn/CryptoNight_monero.h
+++ b/src/crypto/cn/CryptoNight_monero.h
@@ -190,8 +190,8 @@
     r##part[1] = static_cast<uint32_t>(h##part[12] >> 32); \
     r##part[2] = static_cast<uint32_t>(h##part[13]); \
     r##part[3] = static_cast<uint32_t>(h##part[13] >> 32); \
-  } \
-  v4_random_math_init<ALGO>(code##part, height);
+    v4_random_math_init<ALGO>(code##part, height); \
+  }
 
 #define VARIANT4_RANDOM_MATH(part, al, ah, cl, bx0, bx1) \
   if (props.isR()) { \


### PR DESCRIPTION
when I read monero code, I found VARIANT4_RANDOM_MATH_INIT is different
this is monero:
```
#define VARIANT4_RANDOM_MATH_INIT() \
  v4_reg r[9]; \
  struct V4_Instruction code[NUM_INSTRUCTIONS_MAX + 1]; \
  int jit = use_v4_jit(); \
  do if (variant >= 4) \
  { \
    for (int i = 0; i < 4; ++i) \
      V4_REG_LOAD(r + i, (uint8_t*)(state.hs.w + 12) + sizeof(v4_reg) * i); \
    v4_random_math_init(code, height); \
    if (jit) \
    { \
      int ret = v4_generate_JIT_code(code, hp_jitfunc, 4096); \
      if (ret < 0) \
        local_abort("Error generating CryptonightR code"); \
    } \
  } while (0)
```
this is xmrig:
```
#define VARIANT4_RANDOM_MATH_INIT(part) \
  uint32_t r##part[9]; \
  struct V4_Instruction code##part[256]; \
  if (props.isR()) { \
    r##part[0] = static_cast<uint32_t>(h##part[12]); \
    r##part[1] = static_cast<uint32_t>(h##part[12] >> 32); \
    r##part[2] = static_cast<uint32_t>(h##part[13]); \
    r##part[3] = static_cast<uint32_t>(h##part[13] >> 32); \
  } \
  v4_random_math_init<ALGO>(code##part, height);
```
is the v4_random_math_init should be in the "if (props.isR()) "?