### PR TITLE
fix build error on gcc 4.8.5

### DIFF
--- a/src/base/io/log/FileLogWriter.cpp
+++ b/src/base/io/log/FileLogWriter.cpp
@@ -91,7 +91,7 @@ bool xmrig::FileLogWriter::writeLine(const char *data, size_t size)
 {
     const uv_buf_t buf[2] = {
         uv_buf_init(new char[size], size),
-        uv_buf_init(m_endl, sizeof(m_endl) - 1)
+        uv_buf_init((char*)m_endl, sizeof(m_endl) - 1)
     };
 
     memcpy(buf[0].base, data, size);

--- a/src/base/io/log/FileLogWriter.h
+++ b/src/base/io/log/FileLogWriter.h
@@ -42,9 +42,9 @@ public:
 
 private:
 #   ifdef XMRIG_OS_WIN
-    char m_endl[3]  = "\r\n";
+    const char m_endl[3]  = {'\r', '\n', 0};
 #   else
-    char m_endl[2]  = "\n";
+    const char m_endl[2]  = {'\n', 0};
 #   endif
 
     int m_file      = -1;


### PR DESCRIPTION
when build on some old gcc version, such as 9.3.0, is will failed with
`
FileLogWriter.h:34:41: error: array used as initializer
`
