### PR TITLE
Fix: don't use floating point when calculating huge pages percentage

### DIFF
--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -116,7 +116,7 @@ public:
             return;
         }
 
-        LOG_INFO("%s" GREEN_BOLD(" READY") " threads %s%zu/%zu (%zu)" CLEAR " huge pages %s%1.0f%% %zu/%zu" CLEAR " memory " CYAN_BOLD("%zu KB") BLACK_BOLD(" (%" PRIu64 " ms)"),
+        LOG_INFO("%s" GREEN_BOLD(" READY") " threads %s%zu/%zu (%zu)" CLEAR " huge pages %s%d%% %zu/%zu" CLEAR " memory " CYAN_BOLD("%zu KB") BLACK_BOLD(" (%" PRIu64 " ms)"),
                  Tags::cpu(),
                  m_errors == 0 ? CYAN_BOLD_S : YELLOW_BOLD_S,
                  m_started, m_threads, m_ways,

--- a/src/crypto/common/HugePagesInfo.h
+++ b/src/crypto/common/HugePagesInfo.h
@@ -41,7 +41,7 @@ public:
     size_t size         = 0;
 
     inline bool isFullyAllocated() const { return allocated == total; }
-    inline double percent() const        { return allocated == 0 ? 0.0 : static_cast<double>(allocated) / total * 100.0; }
+    inline int percent() const           { return allocated ? static_cast<int>((allocated * 100 + total / 2) / total) : 0; }
     inline void reset()                  { allocated = 0; total = 0; size = 0; }
 
     inline HugePagesInfo &operator+=(const HugePagesInfo &other)

--- a/src/crypto/rx/RxBasicStorage.cpp
+++ b/src/crypto/rx/RxBasicStorage.cpp
@@ -97,7 +97,7 @@ private:
         if (m_dataset->get() != nullptr) {
             const auto pages = m_dataset->hugePages();
 
-            LOG_INFO("%s" GREEN_BOLD("allocated") CYAN_BOLD(" %zu MB") BLACK_BOLD(" (%zu+%zu)") " huge pages %s%1.0f%% %u/%u" CLEAR " %sJIT" BLACK_BOLD(" (%" PRIu64 " ms)"),
+            LOG_INFO("%s" GREEN_BOLD("allocated") CYAN_BOLD(" %zu MB") BLACK_BOLD(" (%zu+%zu)") " huge pages %s%d%% %u/%u" CLEAR " %sJIT" BLACK_BOLD(" (%" PRIu64 " ms)"),
                      Tags::randomx(),
                      pages.size / oneMiB,
                      RxDataset::maxSize() / oneMiB,

--- a/src/crypto/rx/RxNUMAStorage.cpp
+++ b/src/crypto/rx/RxNUMAStorage.cpp
@@ -269,7 +269,7 @@ private:
     {
         const auto pages = dataset->hugePages();
 
-        LOG_INFO("%s" CYAN_BOLD("#%u ") GREEN_BOLD("allocated") CYAN_BOLD(" %zu MB") " huge pages %s%3.0f%%" CLEAR BLACK_BOLD(" (%" PRIu64 " ms)"),
+        LOG_INFO("%s" CYAN_BOLD("#%u ") GREEN_BOLD("allocated") CYAN_BOLD(" %zu MB") " huge pages %s%d%%" CLEAR BLACK_BOLD(" (%" PRIu64 " ms)"),
                  Tags::randomx(),
                  nodeId,
                  pages.size / oneMiB,


### PR DESCRIPTION
I somehow got 101% displayed sometimes.