### PR TITLE
Fixup MacOS CUDA backend default loader name

### DIFF
--- a/src/backend/cuda/wrappers/CudaLib.cpp
+++ b/src/backend/cuda/wrappers/CudaLib.cpp
@@ -48,7 +48,7 @@ enum Version : uint32_t
 static uv_lib_t cudaLib;
 
 #if defined(__APPLE__)
-static String defaultLoader = "/System/Library/Frameworks/OpenCL.framework/OpenCL";
+static String defaultLoader = "libxmrig-cuda.dylib";
 #elif defined(_WIN32)
 static String defaultLoader = "xmrig-cuda.dll";
 #else


### PR DESCRIPTION
Default loader for cuda backend on MacOS was `/System/Library/Frameworks/OpenCL.framework/OpenCL` and has been corrected to match recent MacOS fix for xmrig-cuda.  Copying `libxmrig-cuda.dylib` along side the xmrig executable and `loader: null` works perfectly.