### PR TITLE
Fix --threads generates "*" profile without "kawpow":false to negate it.

### DIFF
--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -43,6 +43,7 @@ static const char *kAsterisk    = "*";
 static const char *kEnabled     = "enabled";
 static const char *kIntensity   = "intensity";
 static const char *kThreads     = "threads";
+static const char *kKawPow      = "kawpow";
 
 
 static inline uint64_t intensity(uint64_t av)
@@ -102,6 +103,7 @@ void xmrig::ConfigTransform::finalize(rapidjson::Document &doc)
         profile.AddMember(StringRef(kThreads),   m_threads, allocator);
         profile.AddMember(StringRef(kAffinity),  m_affinity, allocator);
 
+        doc[CpuConfig::kField].AddMember(StringRef(kKawPow), false, doc.GetAllocator());
         doc[CpuConfig::kField].AddMember(StringRef(kAsterisk), profile, doc.GetAllocator());
     }
 


### PR DESCRIPTION
When generating a catch-all Asterisk thread profile for CPU backend, it enables kawpow.

Fix is to generate a `kawpow:false` to negate the catch-all and ensure kawpow is always deeply disabled for CPU.