### PR TITLE
Fix compile warning/crash when WITH_RANDOMX=OFF

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -274,9 +274,9 @@ void xmrig::CpuWorker<N>::start()
             bool valid = true;
 
             uint8_t miner_signature_saved[64];
-            uint8_t* miner_signature_ptr = m_job.blob() + m_job.nonceOffset() + m_job.nonceSize();
 
 #           ifdef XMRIG_ALGO_RANDOMX
+            uint8_t* miner_signature_ptr = m_job.blob() + m_job.nonceOffset() + m_job.nonceSize();
             if (job.algorithm().family() == Algorithm::RANDOM_X) {
                 if (first) {
                     first = false;


### PR DESCRIPTION
Some compilers seem to have `-Werror` by default (clang-14?) and this warning caused compilation crash if `WITH_RANDOMX` is off.  Move definition of `miner_signature_ptr` to within the `#ifdef XMRIG_ALGO_RANDOMX` block.

```
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp: In instantiation of ‘void xmrig::CpuWorker<N>::start() [with long unsigned int N = 1]’:
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:481:16:   required from here
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:277:22: warning: unused variable ‘miner_signature_ptr’ [-Wunused-variable]
  277 |             uint8_t* miner_signature_ptr = m_job.blob() + m_job.nonceOffset() + m_job.nonceSize();
      |                      ^~~~~~~~~~~~~~~~~~~
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp: In instantiation of ‘void xmrig::CpuWorker<N>::start() [with long unsigned int N = 2]’:
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:482:16:   required from here
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:277:22: warning: unused variable ‘miner_signature_ptr’ [-Wunused-variable]
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp: In instantiation of ‘void xmrig::CpuWorker<N>::start() [with long unsigned int N = 3]’:
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:483:16:   required from here
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:277:22: warning: unused variable ‘miner_signature_ptr’ [-Wunused-variable]
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp: In instantiation of ‘void xmrig::CpuWorker<N>::start() [with long unsigned int N = 4]’:
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:484:16:   required from here
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:277:22: warning: unused variable ‘miner_signature_ptr’ [-Wunused-variable]
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp: In instantiation of ‘void xmrig::CpuWorker<N>::start() [with long unsigned int N = 5]’:
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:485:16:   required from here
/usr/src/xmrig/src/backend/cpu/CpuWorker.cpp:277:22: warning: unused variable ‘miner_signature_ptr’ [-Wunused-variable]
```