### PR TITLE
Fix #2583 compiling without kawpow (string ref is nonexistent then)

### DIFF
--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -103,7 +103,9 @@ void xmrig::ConfigTransform::finalize(rapidjson::Document &doc)
         profile.AddMember(StringRef(kThreads),   m_threads, allocator);
         profile.AddMember(StringRef(kAffinity),  m_affinity, allocator);
 
+#       ifdef XMRIG_ALGO_KAWPOW
         doc[CpuConfig::kField].AddMember(StringRef(Algorithm::kKAWPOW), false, doc.GetAllocator());
+#       endif
         doc[CpuConfig::kField].AddMember(StringRef(kAsterisk), profile, doc.GetAllocator());
     }
 


### PR DESCRIPTION
Previous PR #2583 needed `#ifdef` protection around `Algorithm::kKAWPOW` since it doesn't exist when `XMRIG_ALGO_KAWPOW` is not set.