### PR TITLE
fix: expand validation of tx_extra for merge mining tag

### DIFF
--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -72,7 +72,14 @@ int64_t xmrig::SelfSelectClient::submit(const JobResult &result)
         submitOriginDaemon(result);
     }
 
-    return m_client->submit(result);
+    uint64_t submit_result = m_client->submit(result);
+
+    if (m_submitToOrigin) {
+        // Ensure that the latest block template is available after block submission
+        getBlockTemplate();
+    }
+
+    return submit_result;
 }
 
 
@@ -285,9 +292,6 @@ void xmrig::SelfSelectClient::submitOriginDaemon(const JobResult& result)
     LOG_INFO("%s " GREEN_BOLD("submitted to origin daemon") " (%" PRId64 "/%" PRId64 ") " 
         " diff " WHITE("%" PRIu64) " vs. " WHITE("%" PRIu64),
         Tags::origin(), m_originSubmitted, m_originNotSubmitted, m_blockDiff, result.actualDiff(), result.diff);
-
-    // Ensure that the latest block template is available after block submission
-    getBlockTemplate();
 }
 
 void xmrig::SelfSelectClient::onHttpData(const HttpData &data)

--- a/src/base/tools/cryptonote/BlockTemplate.cpp
+++ b/src/base/tools/cryptonote/BlockTemplate.cpp
@@ -249,10 +249,11 @@ bool xmrig::BlockTemplate::parse(bool hashes)
 
         switch (extra_tag) {
         case 0x01: // TX_EXTRA_TAG_PUBKEY
+        {
             setOffset(TX_PUBKEY_OFFSET, offset(TX_EXTRA_OFFSET) + ar_extra.index());
             ar_extra.skip(kKeySize);
             break;
-
+        }
         case 0x02: // TX_EXTRA_NONCE
             {
                 uint64_t size = 0;
@@ -261,7 +262,14 @@ bool xmrig::BlockTemplate::parse(bool hashes)
                 ar_extra(m_txExtraNonce, size);
             }
             break;
-
+        case 0x03: // TX_EXTRA_MERGE_MINING_TAG
+        {
+            uint64_t size = 0;
+            ar_extra(size);
+            setOffset(TX_EXTRA_MERGE_MINING_TAG_OFFSET, offset(TX_EXTRA_OFFSET) + ar_extra.index());
+            ar_extra(m_txMergeMiningTag, size+kKeySize);
+            break;
+        }
         default:
             return false; // TODO(SChernykh): handle other tags
         }

--- a/src/base/tools/cryptonote/BlockTemplate.h
+++ b/src/base/tools/cryptonote/BlockTemplate.h
@@ -54,6 +54,7 @@ public:
         TX_EXTRA_OFFSET,
         TX_PUBKEY_OFFSET,
         TX_EXTRA_NONCE_OFFSET,
+        TX_EXTRA_MERGE_MINING_TAG_OFFSET,
         OFFSET_COUNT
     };
 
@@ -86,6 +87,7 @@ public:
     inline uint64_t outputType() const                      { return m_outputType; }
     inline const Span &ephPublicKey() const                 { return m_ephPublicKey; }
     inline const Span &txExtraNonce() const                 { return m_txExtraNonce; }
+    inline const Span &txMergeMiningTag() const             { return m_txMergeMiningTag; }
 
     // Transaction hashes
     inline uint64_t numHashes() const                       { return m_numHashes; }
@@ -140,7 +142,7 @@ private:
     Span m_ephPublicKey;
     uint64_t m_extraSize    = 0;
     Span m_txExtraNonce;
-
+    Span m_txMergeMiningTag = 0;
     uint64_t m_numHashes    = 0;
     Buffer m_hashes;
     Buffer m_minerTxMerkleTreeBranch;


### PR DESCRIPTION
This PR expands the parsing of the block template to include the merge mining tag.

Currently if the merged mining tag is present in the template it will fail to be parsed even though it is a valid tag.

Additionally the changes to SelfSelectClient.cpp appears to reduce the frequency of this issue:
https://github.com/xmrig/xmrig/issues/2609