### PR TITLE
Patch a couple minor leaks

### DIFF
--- a/src/base/net/dns/DnsUvBackend.cpp
+++ b/src/base/net/dns/DnsUvBackend.cpp
@@ -28,11 +28,17 @@
 
 namespace xmrig {
 
+static Storage<DnsUvBackend>* storage = nullptr;
 
 Storage<DnsUvBackend>& DnsUvBackend::getStorage()
 {
-    static Storage<DnsUvBackend>* storage = new Storage<DnsUvBackend>();
+    if (storage == nullptr) storage = new Storage<DnsUvBackend>();
     return *storage;
+}
+
+void DnsUvBackend::releaseStorage()
+{
+    delete storage;
 }
 
 static addrinfo hints{};
@@ -56,6 +62,7 @@ xmrig::DnsUvBackend::DnsUvBackend()
 xmrig::DnsUvBackend::~DnsUvBackend()
 {
     getStorage().release(m_key);
+    releaseStorage();
 }
 
 

--- a/src/base/net/dns/DnsUvBackend.h
+++ b/src/base/net/dns/DnsUvBackend.h
@@ -62,6 +62,7 @@ private:
     uintptr_t m_key;
 
     static Storage<DnsUvBackend>& getStorage();
+    void releaseStorage();
 };
 
 

--- a/src/crypto/cn/CnHash.cpp
+++ b/src/crypto/cn/CnHash.cpp
@@ -316,6 +316,14 @@ xmrig::CnHash::CnHash()
 }
 
 
+xmrig::CnHash::~CnHash()
+{
+    for (auto const& x : m_map) {
+      delete m_map[x.first];
+    }
+}
+
+
 xmrig::cn_hash_fun xmrig::CnHash::fn(const Algorithm &algorithm, AlgoVariant av, Assembly::Id assembly)
 {
     assert(cnHash.m_map.count(algorithm));

--- a/src/crypto/cn/CnHash.h
+++ b/src/crypto/cn/CnHash.h
@@ -59,6 +59,7 @@ public:
     };
 
     CnHash();
+    virtual ~CnHash();
 
     static cn_hash_fun fn(const Algorithm &algorithm, AlgoVariant av, Assembly::Id assembly);
 

--- a/src/crypto/randomx/randomx.cpp
+++ b/src/crypto/randomx/randomx.cpp
@@ -410,6 +410,7 @@ extern "C" {
 	}
 
 	void randomx_release_cache(randomx_cache* cache) {
+		delete cache->jit;
 		delete cache;
 	}
 


### PR DESCRIPTION
A couple minor leaks found with valgrind:
* DnsUvBackend: `getStorage()` var `*storage` modified to global singleton, add `releaseStorage()` method and call it in destructor
* CnHash: add destructor to clear the function table at shutdown
* randomx: `randomx_release_cache()` add deletion of JIT cache