### PR TITLE
Benchmark support for GhostRider (offline only)

### DIFF
--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -87,6 +87,7 @@ public:
         SpendSecretKey       = 1055,
         DaemonZMQPortKey     = 1056,
         HugePagesJitKey      = 1057,
+        RotationKey          = 1058,
 
         // xmrig common
         CPUPriorityKey       = 1021,

--- a/src/base/net/stratum/benchmark/BenchClient.cpp
+++ b/src/base/net/stratum/benchmark/BenchClient.cpp
@@ -48,6 +48,39 @@ xmrig::BenchClient::BenchClient(const std::shared_ptr<BenchConfig> &benchmark, I
     std::vector<char> blob(112 * 2 + 1, '0');
     blob.back() = '\0';
 
+#   ifdef XMRIG_ALGO_GHOSTRIDER
+    if (m_benchmark->algorithm() == Algorithm::GHOSTRIDER_RTM) {
+        const uint32_t r = benchmark->rotation() % 20;
+
+        static constexpr uint32_t indices[20][3] = {
+             { 0, 1, 2 },
+             { 0, 1, 3 },
+             { 0, 1, 4 },
+             { 0, 1, 5 },
+             { 0, 2, 3 },
+             { 0, 2, 4 },
+             { 0, 2, 5 },
+             { 0, 3, 4 },
+             { 0, 3, 5 },
+             { 0, 4, 5 },
+             { 1, 2, 3 },
+             { 1, 2, 4 },
+             { 1, 2, 5 },
+             { 1, 3, 4 },
+             { 1, 3, 5 },
+             { 1, 4, 5 },
+             { 2, 3, 4 },
+             { 2, 3, 5 },
+             { 2, 4, 5 },
+             { 3, 4, 5 },
+        };
+
+        blob[ 8] = '0' + indices[r][1];
+        blob[ 9] = '0' + indices[r][0];
+        blob[11] = '0' + indices[r][2];
+    }
+#   endif
+
     m_job.setAlgorithm(m_benchmark->algorithm());
     m_job.setBlob(blob.data());
     m_job.setDiff(std::numeric_limits<uint64_t>::max());
@@ -60,7 +93,7 @@ xmrig::BenchClient::BenchClient(const std::shared_ptr<BenchConfig> &benchmark, I
     BenchState::init(this, m_benchmark->size());
 
 #   ifdef XMRIG_FEATURE_HTTP
-    if (m_benchmark->isSubmit()) {
+    if (m_benchmark->isSubmit() && (m_benchmark->algorithm().family() == Algorithm::RANDOM_X)) {
         m_mode  = ONLINE_BENCH;
         m_token = m_benchmark->token();
 

--- a/src/base/net/stratum/benchmark/BenchConfig.h
+++ b/src/base/net/stratum/benchmark/BenchConfig.h
@@ -37,6 +37,7 @@ public:
     static const char *kId;
     static const char *kSeed;
     static const char *kSize;
+    static const char* kRotation;
     static const char *kSubmit;
     static const char *kToken;
     static const char *kUser;
@@ -50,7 +51,7 @@ public:
     static constexpr const uint16_t kApiPort    = 18805;
 #   endif
 
-    BenchConfig(uint32_t size, const String &id, const rapidjson::Value &object, bool dmi);
+    BenchConfig(uint32_t size, const String &id, const rapidjson::Value &object, bool dmi, uint32_t rotation);
 
     static BenchConfig *create(const rapidjson::Value &object, bool dmi);
 
@@ -63,6 +64,7 @@ public:
     inline const String &user() const           { return m_user; }
     inline uint32_t size() const                { return m_size; }
     inline uint64_t hash() const                { return m_hash; }
+    inline uint32_t rotation() const            { return m_rotation; }
 
     rapidjson::Value toJSON(rapidjson::Document &doc) const;
 
@@ -77,6 +79,7 @@ private:
     String m_token;
     String m_user;
     uint32_t m_size;
+    uint32_t m_rotation;
     uint64_t m_hash = 0;
 };
 

--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -269,6 +269,7 @@ void xmrig::ConfigTransform::transform(rapidjson::Document &doc, int key, const 
     case IConfig::BenchSeedKey:     /* --seed */
     case IConfig::BenchHashKey:     /* --hash */
     case IConfig::UserKey:          /* --user */
+    case IConfig::RotationKey:      /* --rotation */
         return transformBenchmark(doc, key, arg);
 #   endif
 
@@ -357,6 +358,9 @@ void xmrig::ConfigTransform::transformBenchmark(rapidjson::Document &doc, int ke
 
     case IConfig::UserKey: /* --user */
         return set(doc, BenchConfig::kBenchmark, BenchConfig::kUser, arg);
+
+    case IConfig::RotationKey: /* --rotation */
+        return set(doc, BenchConfig::kBenchmark, BenchConfig::kRotation, arg);
 
     default:
         break;

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -71,6 +71,7 @@ static const option options[] = {
     { "hugepage-size",         1, nullptr, IConfig::HugePageSizeKey       },
     { "huge-pages-jit",        0, nullptr, IConfig::HugePagesJitKey       },
     { "hugepages-jit",         0, nullptr, IConfig::HugePagesJitKey       },
+    { "rotation",              1, nullptr, IConfig::RotationKey           },
     { "pass",                  1, nullptr, IConfig::PasswordKey           },
     { "print-time",            1, nullptr, IConfig::PrintTimeKey          },
     { "retries",               1, nullptr, IConfig::RetriesKey            },


### PR DESCRIPTION
Command line:
```
./xmrig --bench=250K -a gr --rotation 15
```
Where `rotation` is an integer between 0 and 19 (inclusive) - GhostRider has 20 different combinations of algorithms that have different hashrates.