### PR TITLE
Only initGhostRider() when job is in the family

### DIFF
--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -564,7 +564,9 @@ void xmrig::Miner::setJob(const Job &job, bool donate)
 #   endif
 
 #   ifdef XMRIG_ALGO_GHOSTRIDER
-    d_ptr->initGhostRider();
+    if (job.algorithm().family() == Algorithm::GHOSTRIDER) {
+        d_ptr->initGhostRider();
+    }
 #   endif
 
     mutex.unlock();


### PR DESCRIPTION
Was benchmarking GhostRider simultaneous to RandomX init, probably unintended and inaccurate