### PR TITLE
Fix compile for VAES support with GCC<10

### DIFF
--- a/src/crypto/cn/CryptoNight_x86_vaes.cpp
+++ b/src/crypto/cn/CryptoNight_x86_vaes.cpp
@@ -30,6 +30,23 @@
 
 #ifdef __GNUC__
 #   include <x86intrin.h>
+#if !defined(__clang__) && !defined(__ICC) && __GNUC__ < 10
+static inline __m256i
+__attribute__((__always_inline__))
+  _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
+{
+    return _mm256_inserti128_si256(
+            _mm256_castsi128_si256(_mm_loadu_si128(loaddr)), _mm_loadu_si128(hiaddr), 1);
+}
+
+static inline void
+__attribute__((__always_inline__))
+  _mm256_storeu2_m128i(__m128i* const hiaddr, __m128i* const loaddr, const __m256i a)
+{
+    _mm_storeu_si128(loaddr, _mm256_castsi256_si128(a));
+      _mm_storeu_si128(hiaddr, _mm256_extracti128_si256(a, 1));
+}
+#endif
 #else
 #   include <intrin.h>
 #endif


### PR DESCRIPTION
Stubs for missing intrinsics

Attempting to figure out the actual line, but for now 10.0.0 seems fine.  Tested with 10.3.0... might still be missing in between 9.3.0 and 10.3.0 somewhere.  Could be a more robust way to detect the missing functions directly, and not use versions at all...