### PR TITLE
Updated GhostRider documentation

### DIFF
--- a/scripts/rtm_ghostrider_example.cmd
+++ b/scripts/rtm_ghostrider_example.cmd
@@ -16,5 +16,8 @@
 :: Smaller pools also often have smaller fees/payout limits.
 
 cd %~dp0
+:: Use this command line to connect to non-SSL port
 xmrig.exe -a gr -o raptoreumemporium.com:3008 -u WALLET_ADDRESS -p x
+:: Or use this command line to connect to an SSL port
+:: xmrig.exe -a gr -o rtm.suprnova.cc:4273 --tls -u WALLET_ADDRESS -p x
 pause

--- a/src/crypto/ghostrider/README.md
+++ b/src/crypto/ghostrider/README.md
@@ -6,12 +6,12 @@ No tuning is required - auto-config works well on most CPUs!
 
 ### Sample command line (non-SSL port)
 ```
-xmrig -a gr -o raptoreumemporium.com:3008 -u WALLET_ADDRESS
+xmrig -a gr -o raptoreumemporium.com:3008 -u WALLET_ADDRESS -p x
 ```
 
 ### Sample command line (SSL port)
 ```
-xmrig -a gr -o us.flockpool.com:5555 --tls -u WALLET_ADDRESS
+xmrig -a gr -o rtm.suprnova.cc:4273 --tls -u WALLET_ADDRESS -p x
 ```
 
 You can use **rtm_ghostrider_example.cmd** as a template and put pool URL and your wallet address there. The general XMRig documentation is available [here](https://xmrig.com/docs/miner).


### PR DESCRIPTION
Added examples for SSL port command line that don't use #1 pool.