### PR TITLE
Adding /d switch

### DIFF
--- a/scripts/rtm_ghostrider_example.cmd
+++ b/scripts/rtm_ghostrider_example.cmd
@@ -15,6 +15,6 @@
 :: Choose pools outside of top 5 to help Raptoreum network be more decentralized!
 :: Smaller pools also often have smaller fees/payout limits.
 
-cd %~dp0
+cd /d "%~dp0"
 xmrig.exe -a gr -o raptoreumemporium.com:3008 -u WALLET_ADDRESS -p x
 pause


### PR DESCRIPTION
1. Adding `/d` to change current drive in addition to changing current directory for a drive.
2. Enclose quote `"%~dp0"` allow space in `cd` command (to be safe).
3. Allow user run this script without set **Administrator** in properties.

Running `*.cmd` As Administrator will spawn on `C:\WINDOWS\system32` and break if `xmrig.exe` not in `C:\` (Default UAC)