### PR TITLE
RandomX: don't restart mining threads when the seed changes

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -134,7 +134,7 @@ void xmrig::CpuWorker<N>::allocateRandomX_VM()
     RxDataset *dataset = Rx::dataset(m_job.currentJob(), node());
 
     while (dataset == nullptr) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
         if (Nonce::sequence(Nonce::CPU) == 0) {
             return;
@@ -246,7 +246,7 @@ void xmrig::CpuWorker<N>::start()
     while (Nonce::sequence(Nonce::CPU) > 0) {
         if (Nonce::isPaused()) {
             do {
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
             }
             while (Nonce::isPaused() && Nonce::sequence(Nonce::CPU) > 0);
 

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -553,7 +553,13 @@ void xmrig::Miner::setJob(const Job &job, bool donate)
 
 #   ifdef XMRIG_ALGO_RANDOMX
     if (job.algorithm().family() == Algorithm::RANDOM_X && !Rx::isReady(job)) {
-        stop();
+        if (d_ptr->algorithm != job.algorithm()) {
+            stop();
+        }
+        else {
+            Nonce::pause(true);
+            Nonce::touch();
+        }
     }
 #   endif
 

--- a/src/crypto/rx/RxQueue.cpp
+++ b/src/crypto/rx/RxQueue.cpp
@@ -154,6 +154,8 @@ void xmrig::RxQueue::backgroundInit()
             continue;
         }
 
+        // Update seed here again in case there was more than one item in the queue
+        m_seed = item.seed;
         m_state = STATE_IDLE;
         m_async->send();
     }


### PR DESCRIPTION
It helps to not loose huge pages when the seed changes (every 2048 blocks, ~2.8 days).