### PR TITLE
armv7 compilation fix

### DIFF
--- a/src/crypto/cn/sse2neon.h
+++ b/src/crypto/cn/sse2neon.h
@@ -344,7 +344,7 @@ typedef union ALIGN_STRUCT(16) SIMDVec {
 
 // Older gcc does not define vld1q_u8_x4 type
 #if defined(__GNUC__) && !defined(__clang__) &&                        \
-    ((__GNUC__ <= 10 && defined(__arm__)) ||                           \
+    ((__GNUC__ <= 11 && defined(__arm__)) ||                           \
      (__GNUC__ == 10 && __GNUC_MINOR__ < 3 && defined(__aarch64__)) || \
      (__GNUC__ <= 9 && defined(__aarch64__)))
 FORCE_INLINE uint8x16x4_t _sse2neon_vld1q_u8_x4(const uint8_t *p)


### PR DESCRIPTION
Compilation fails for armv7 on gcc 11, and updating the version in that line fixes it.