### PR TITLE
Add MSVC/2022 to version.h

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -33,7 +33,9 @@
 #define APP_VER_PATCH  4
 
 #ifdef _MSC_VER
-#   if (_MSC_VER >= 1920)
+#   if (_MSC_VER >= 1930)
+#       define MSVC_VERSION 2022
+#   elif (_MSC_VER >= 1920 && _MSC_VER < 1930)
 #       define MSVC_VERSION 2019
 #   elif (_MSC_VER >= 1910 && _MSC_VER < 1920)
 #       define MSVC_VERSION 2017


### PR DESCRIPTION
19.30+ is MSVC/2022 -- this fixes compiler info in version strings