### PR TITLE
update build.hwloc.sh to download v.2.6.0 (stable)

### DIFF
--- a/scripts/build.hwloc.sh
+++ b/scripts/build.hwloc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-HWLOC_VERSION="2.5.0"
+HWLOC_VERSION="2.6.0"
 
 mkdir -p deps
 mkdir -p deps/include
@@ -8,7 +8,7 @@ mkdir -p deps/lib
 
 mkdir -p build && cd build
 
-wget https://download.open-mpi.org/release/hwloc/v2.5/hwloc-${HWLOC_VERSION}.tar.gz -O hwloc-${HWLOC_VERSION}.tar.gz
+wget https://download.open-mpi.org/release/hwloc/v2.6/hwloc-${HWLOC_VERSION}.tar.gz -O hwloc-${HWLOC_VERSION}.tar.gz
 tar -xzf hwloc-${HWLOC_VERSION}.tar.gz
 
 cd hwloc-${HWLOC_VERSION}


### PR DESCRIPTION
hwloc 2.6.0 is the latest stable version, 2.5.0 is listed as "old." 