### PR TITLE
update build.libressl.sh to d/l v 3.4.2

### DIFF
--- a/scripts/build.libressl.sh
+++ b/scripts/build.libressl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-LIBRESSL_VERSION="3.0.2"
+LIBRESSL_VERSION="3.4.2"
 
 mkdir -p deps
 mkdir -p deps/include


### PR DESCRIPTION
script downloads 3.0.2; 3.4.2 is the latest release. Updated to reflect latest version