### PR TITLE
astrobwt: fix build with gcc-4.8

### DIFF
--- a/src/crypto/astrobwt/sort_indices2.cpp
+++ b/src/crypto/astrobwt/sort_indices2.cpp
@@ -36,6 +36,9 @@
 #define RESTRICT
 #endif
 
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
 
 #if __has_cpp_attribute(unlikely)
 #define UNLIKELY(X) (X) [[unlikely]]


### PR DESCRIPTION
Fixes build error:

xmrig-6.17.0/src/crypto/astrobwt/sort_indices2.cpp:40:24: error: missing binary operator before token "("
 #if __has_cpp_attribute(unlikely)

found with the buildroot toolchain
arm-none-linux-gnueabi-gcc (Sourcery CodeBench Lite 2014.05-29) 4.8.3 20140320 (prerelease)

Inspired by
https://reviews.llvm.org/rG91c32fd8c8fa395971a028f7091273fa2c8f44e6