### PR TITLE
Add x86 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 XMRig is a high performance, open source, cross platform RandomX, KawPow, CryptoNight, AstroBWT and [GhostRider](https://github.com/xmrig/xmrig/tree/master/src/crypto/ghostrider#readme) unified CPU/GPU miner and [RandomX benchmark](https://xmrig.com/benchmark). Official binaries are available for Windows, Linux, macOS and FreeBSD.
 
 ## Mining backends
-- **CPU** (x64/ARMv7/ARMv8)
+- **CPU** (x86/x64/ARMv7/ARMv8)
 - **OpenCL** for AMD GPUs.
 - **CUDA** for NVIDIA GPUs via external [CUDA plugin](https://github.com/xmrig/xmrig-cuda).
 


### PR DESCRIPTION
Sorry to create a second PR, but I didn't catch this last time. XMRig also supports 32 bit x86, which I just tested, so I'm adding that to the README.