### PR TITLE
add armv8l architecture

### DIFF
--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -29,7 +29,7 @@ else()
 endif()
 
 if (NOT ARM_TARGET)
-    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a|armv8ls)$")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a|armv8l)$")
         set(ARM_TARGET 8)
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|armv7f|armv7s|armv7k|armv7-a|armv7l)$")
         set(ARM_TARGET 7)

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -29,7 +29,7 @@ else()
 endif()
 
 if (NOT ARM_TARGET)
-    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a)$")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a|armv8l)$")
         set(ARM_TARGET 8)
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|armv7f|armv7s|armv7k|armv7-a|armv7l)$")
         set(ARM_TARGET 7)

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -29,7 +29,7 @@ else()
 endif()
 
 if (NOT ARM_TARGET)
-    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a|armv8l)$")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|armv8-a|armv8ls)$")
         set(ARM_TARGET 8)
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|armv7f|armv7s|armv7k|armv7-a|armv7l)$")
         set(ARM_TARGET 7)


### PR DESCRIPTION
I'am currently running ubuntu on android terminal emulator for compiling xmrig.
but failed because the different architecture name, but actually is same with aarch64, arm64, or armv8-a.
the app package name is: jackpal.androidterm and can downloaded from playstore.
without adding armv8l architecture to cpu.cmake, I can't compile xmrig on my ubuntu because the gcc keep with error message.
after I'am adding armv8l arch name to cmake/cpu.cmake the compilation procces completed with succesfull.
can you to change your files too...???
because is very helpfully for people like me.
Thankyou...   :D 