### PR TITLE
Don't reset when pool sends the same job blob

### DIFF
--- a/src/base/net/stratum/Job.cpp
+++ b/src/base/net/stratum/Job.cpp
@@ -48,7 +48,13 @@ xmrig::Job::Job(bool nicehash, const Algorithm &algorithm, const String &clientI
 
 bool xmrig::Job::isEqual(const Job &other) const
 {
-    return m_id == other.m_id && m_clientId == other.m_clientId && memcmp(m_blob, other.m_blob, sizeof(m_blob)) == 0 && m_target == other.m_target;
+    return m_id == other.m_id && m_clientId == other.m_clientId && isEqualBlob(other) && m_target == other.m_target;
+}
+
+
+bool xmrig::Job::isEqualBlob(const Job &other) const
+{
+    return (m_size == other.m_size) && (memcmp(m_blob, other.m_blob, m_size) == 0);
 }
 
 

--- a/src/base/net/stratum/Job.h
+++ b/src/base/net/stratum/Job.h
@@ -59,6 +59,7 @@ public:
     ~Job() = default;
 
     bool isEqual(const Job &other) const;
+    bool isEqualBlob(const Job &other) const;
     bool setBlob(const char *blob);
     bool setSeedHash(const char *hash);
     bool setTarget(const char *target);

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -561,6 +561,12 @@ void xmrig::Miner::setJob(const Job &job, bool donate)
     const uint8_t index = donate ? 1 : 0;
 
     d_ptr->reset = !(d_ptr->job.index() == 1 && index == 0 && d_ptr->userJobId == job.id());
+
+    // Don't reset nonce if pool sends the same hashing blob again, but with different difficulty (for example)
+    if (d_ptr->job.isEqualBlob(job)) {
+        d_ptr->reset = false;
+    }
+
     d_ptr->job   = job;
     d_ptr->job.setIndex(index);
 


### PR DESCRIPTION
Some pools can send the same job again after changing job difficulty, see https://github.com/xmrig/xmrig/issues/3125