### PR TITLE
Update cmake required version to 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(xmrig)
 
 option(WITH_HWLOC           "Enable hwloc support" ON)


### PR DESCRIPTION
`set(CMAKE_CXX_STANDARD 11)` only works properly starting from cmake 3.1, see #3174