### PR TITLE
Solo mining: added job timeout (default is 15 seconds)

### DIFF
--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -247,6 +247,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::HttpPort:         /* --http-port */
     case IConfig::DonateLevelKey:   /* --donate-level */
     case IConfig::DaemonPollKey:    /* --daemon-poll-interval */
+    case IConfig::DaemonJobTimeoutKey: /* --daemon-job-timeout */
     case IConfig::DnsTtlKey:        /* --dns-ttl */
     case IConfig::DaemonZMQPortKey: /* --daemon-zmq-port */
         return transformUint64(doc, key, static_cast<uint64_t>(strtol(arg, nullptr, 10)));
@@ -359,6 +360,9 @@ void xmrig::BaseTransform::transformUint64(rapidjson::Document &doc, int key, ui
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonPollKey:  /* --daemon-poll-interval */
         return add(doc, Pools::kPools, Pool::kDaemonPollInterval, arg);
+
+    case IConfig::DaemonJobTimeoutKey:  /* --daemon-job-timeout */
+        return add(doc, Pools::kPools, Pool::kDaemonJobTimeout, arg);
 
     case IConfig::DaemonZMQPortKey:  /* --daemon-zmq-port */
         return add(doc, Pools::kPools, Pool::kDaemonZMQPort, arg);

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -88,6 +88,7 @@ public:
         DaemonZMQPortKey     = 1056,
         HugePagesJitKey      = 1057,
         RotationKey          = 1058,
+        DaemonJobTimeoutKey  = 1059,
 
         // xmrig common
         CPUPriorityKey       = 1021,

--- a/src/base/net/stratum/DaemonClient.h
+++ b/src/base/net/stratum/DaemonClient.h
@@ -104,6 +104,7 @@ private:
     String m_blocktemplateStr;
     String m_currentJobId;
     String m_prevHash;
+    uint64_t m_jobSteadyMs = 0;
     String m_tlsFingerprint;
     String m_tlsVersion;
     Timer *m_timer;

--- a/src/base/net/stratum/Pool.cpp
+++ b/src/base/net/stratum/Pool.cpp
@@ -65,6 +65,7 @@ const char *Pool::kAlgo                   = "algo";
 const char *Pool::kCoin                   = "coin";
 const char *Pool::kDaemon                 = "daemon";
 const char *Pool::kDaemonPollInterval     = "daemon-poll-interval";
+const char *Pool::kDaemonJobTimeout       = "daemon-job-timeout";
 const char *Pool::kDaemonZMQPort          = "daemon-zmq-port";
 const char *Pool::kEnabled                = "enabled";
 const char *Pool::kFingerprint            = "tls-fingerprint";
@@ -88,6 +89,7 @@ const char *Pool::kNicehashHost           = "nicehash.com";
 xmrig::Pool::Pool(const char *url) :
     m_flags(1 << FLAG_ENABLED),
     m_pollInterval(kDefaultPollInterval),
+    m_jobTimeout(kDefaultJobTimeout),
     m_url(url)
 {
 }
@@ -101,6 +103,7 @@ xmrig::Pool::Pool(const char *host, uint16_t port, const char *user, const char 
     m_user(user),
     m_spendSecretKey(spendSecretKey),
     m_pollInterval(kDefaultPollInterval),
+    m_jobTimeout(kDefaultJobTimeout),
     m_url(host, port, tls)
 {
     m_flags.set(FLAG_NICEHASH, nicehash || strstr(host, kNicehashHost));
@@ -111,6 +114,7 @@ xmrig::Pool::Pool(const char *host, uint16_t port, const char *user, const char 
 xmrig::Pool::Pool(const rapidjson::Value &object) :
     m_flags(1 << FLAG_ENABLED),
     m_pollInterval(kDefaultPollInterval),
+    m_jobTimeout(kDefaultJobTimeout),
     m_url(Json::getString(object, kUrl))
 {
     if (!m_url.isValid()) {
@@ -123,6 +127,7 @@ xmrig::Pool::Pool(const rapidjson::Value &object) :
     m_rigId          = Json::getString(object, kRigId);
     m_fingerprint    = Json::getString(object, kFingerprint);
     m_pollInterval   = Json::getUint64(object, kDaemonPollInterval, kDefaultPollInterval);
+    m_jobTimeout     = Json::getUint64(object, kDaemonJobTimeout, kDefaultJobTimeout);
     m_algorithm      = Json::getString(object, kAlgo);
     m_coin           = Json::getString(object, kCoin);
     m_daemon         = Json::getString(object, kSelfSelect);
@@ -207,6 +212,7 @@ bool xmrig::Pool::isEqual(const Pool &other) const
             && m_url          == other.m_url
             && m_user         == other.m_user
             && m_pollInterval == other.m_pollInterval
+            && m_jobTimeout   == other.m_jobTimeout
             && m_daemon       == other.m_daemon
             && m_proxy        == other.m_proxy
             );
@@ -299,6 +305,7 @@ rapidjson::Value xmrig::Pool::toJSON(rapidjson::Document &doc) const
 
     if (m_mode == MODE_DAEMON) {
         obj.AddMember(StringRef(kDaemonPollInterval), m_pollInterval, allocator);
+        obj.AddMember(StringRef(kDaemonJobTimeout), m_jobTimeout, allocator);
         obj.AddMember(StringRef(kDaemonZMQPort), m_zmqPort, allocator);
     }
     else {

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -59,6 +59,7 @@ public:
     static const char *kCoin;
     static const char *kDaemon;
     static const char *kDaemonPollInterval;
+    static const char* kDaemonJobTimeout;
     static const char *kEnabled;
     static const char *kFingerprint;
     static const char *kKeepalive;
@@ -78,6 +79,7 @@ public:
     constexpr static int kKeepAliveTimeout         = 60;
     constexpr static uint16_t kDefaultPort         = 3333;
     constexpr static uint64_t kDefaultPollInterval = 1000;
+    constexpr static uint64_t kDefaultJobTimeout   = 15000;
 
     Pool() = default;
     Pool(const char *host, uint16_t port, const char *user, const char *password, const char* spendSecretKey, int keepAlive, bool nicehash, bool tls, Mode mode);
@@ -110,6 +112,7 @@ public:
     inline uint16_t port() const                        { return m_url.port(); }
     inline int zmq_port() const                         { return m_zmqPort; }
     inline uint64_t pollInterval() const                { return m_pollInterval; }
+    inline uint64_t jobTimeout() const                  { return m_jobTimeout; }
     inline void setAlgo(const Algorithm &algorithm)     { m_algorithm = algorithm; }
     inline void setUrl(const char *url)                 { m_url = Url(url); }
     inline void setPassword(const String &password)     { m_password = password; }
@@ -156,6 +159,7 @@ private:
     String m_user;
     String m_spendSecretKey;
     uint64_t m_pollInterval         = kDefaultPollInterval;
+    uint64_t m_jobTimeout           = kDefaultJobTimeout;
     Url m_daemon;
     Url m_url;
     int m_zmqPort                   = -1;

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -50,6 +50,7 @@ static const option options[] = {
     { "http-no-restricted",    0, nullptr, IConfig::HttpRestrictedKey     },
     { "daemon",                0, nullptr, IConfig::DaemonKey             },
     { "daemon-poll-interval",  1, nullptr, IConfig::DaemonPollKey         },
+    { "daemon-job-timeout",    1, nullptr, IConfig::DaemonJobTimeoutKey   },
     { "self-select",           1, nullptr, IConfig::SelfSelectKey         },
     { "submit-to-origin",      0, nullptr, IConfig::SubmitToOriginKey     },
     { "daemon-zmq-port",       1, nullptr, IConfig::DaemonZMQPortKey      },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -64,7 +64,9 @@ static inline const std::string &usage()
 
 #   ifdef XMRIG_FEATURE_HTTP
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";
+    u += "      --daemon-zmq-port         daemon's zmq-pub port number (only use it if daemon has it enabled)\n";
     u += "      --daemon-poll-interval=N  daemon poll interval in milliseconds (default: 1000)\n";
+    u += "      --daemon-job-timeout=N    daemon job timeout in milliseconds (default: 15000)\n";
     u += "      --self-select=URL         self-select block templates from URL\n";
     u += "      --submit-to-origin        also submit solution back to self-select URL\n";
 #   endif


### PR DESCRIPTION
It's important to update jobs frequently to get new transactions into the block template. See https://rucknium.me/posts/monero-pool-transaction-delay/ for more details.