### PR TITLE
DaemonClient: new X-Hash-Difficulty HTTP header optimization

### DIFF
--- a/src/base/net/stratum/DaemonClient.cpp
+++ b/src/base/net/stratum/DaemonClient.cpp
@@ -178,7 +178,9 @@ int64_t xmrig::DaemonClient::submit(const JobResult &result)
     m_results[m_sequence] = SubmitResult(m_sequence, result.diff, result.actualDiff(), 0, result.backend);
 #   endif
 
-    return rpcSend(doc);
+    std::map<std::string, std::string> headers;
+    headers.insert({"X-Hash-Difficulty", std::to_string(result.actualDiff())});
+    return rpcSend(doc, headers);
 }
 
 
@@ -553,9 +555,11 @@ int64_t xmrig::DaemonClient::getBlockTemplate()
 }
 
 
-int64_t xmrig::DaemonClient::rpcSend(const rapidjson::Document &doc)
+int64_t xmrig::DaemonClient::rpcSend(const rapidjson::Document &doc, const std::map<std::string, std::string> &headers)
 {
     FetchRequest req(HTTP_POST, m_pool.host(), m_pool.port(), kJsonRPC, doc, m_pool.isTLS(), isQuiet());
+    for (const auto &header: headers)
+        req.headers.insert(header);
     fetch(tag(), std::move(req), m_httpListener);
 
     return m_sequence++;

--- a/src/base/net/stratum/DaemonClient.h
+++ b/src/base/net/stratum/DaemonClient.h
@@ -86,7 +86,7 @@ private:
     bool parseJob(const rapidjson::Value &params, int *code);
     bool parseResponse(int64_t id, const rapidjson::Value &result, const rapidjson::Value &error);
     int64_t getBlockTemplate();
-    int64_t rpcSend(const rapidjson::Document &doc);
+    int64_t rpcSend(const rapidjson::Document &doc, const std::map<std::string, std::string> &headers = {});
     void retry();
     void send(const char *path);
     void setState(SocketState state);


### PR DESCRIPTION
If the caller knows the difficulty of a PoW hash a given nonce yields, it can tell the callee via the X-Hash-Difficulty, which may allow the callee to skip some processing if the difficulty does not meet some criterion.

In my case, a merge mining proxy can know it's pointless trying to submit the nonce to a chain with higher difficulty when the nonce only meets the difficulty for a lower difficulty chain.