### PR TITLE
fix(cuda): receive CUDA loader error on linux too.

### DIFF
--- a/src/backend/cuda/wrappers/CudaLib.cpp
+++ b/src/backend/cuda/wrappers/CudaLib.cpp
@@ -353,13 +353,9 @@ bool xmrig::CudaLib::open()
 #   ifdef XMRIG_OS_LINUX
     if (m_loader == defaultLoader) {
         m_loader = Process::location(Process::ExeLocation, m_loader);
-    }
-    else {
-        return false;
-    }
-
-    if (uv_dlopen(m_loader, &cudaLib) == 0) {
-        return true;
+        if (uv_dlopen(m_loader, &cudaLib) == 0) {
+            return true;
+        }
     }
 #   endif
 


### PR DESCRIPTION
Right now if provided cuda loader fails to load on linux it wouldn't show error, instead log  `CUDA: disabled ((null))`
