### PR TITLE
Improve .cmd files when run by shortcuts on another drive

### DIFF
--- a/scripts/benchmark_10M.cmd
+++ b/scripts/benchmark_10M.cmd
@@ -1,4 +1,4 @@
 @echo off
-cd %~dp0
+cd /d "%~dp0"
 xmrig.exe --bench=10M --submit
 pause

--- a/scripts/benchmark_1M.cmd
+++ b/scripts/benchmark_1M.cmd
@@ -1,4 +1,4 @@
 @echo off
-cd %~dp0
+cd /d "%~dp0"
 xmrig.exe --bench=1M --submit
 pause

--- a/scripts/pool_mine_example.cmd
+++ b/scripts/pool_mine_example.cmd
@@ -15,6 +15,6 @@
 :: Choose pools outside of top 5 to help Monero network be more decentralized!
 :: Smaller pools also often have smaller fees/payout limits.
 
-cd %~dp0
+cd /d "%~dp0"
 xmrig.exe -o pool.hashvault.pro:3333 -u 48edfHu7V9Z84YzzMa6fUueoELZ9ZRXq9VetWzYGzKt52XU5xvqgzYnDK9URnRoJMk1j8nLwEVsaSWJ4fhdUyZijBGUicoD -p x
 pause

--- a/scripts/rtm_ghostrider_example.cmd
+++ b/scripts/rtm_ghostrider_example.cmd
@@ -15,7 +15,7 @@
 :: Choose pools outside of top 5 to help Raptoreum network be more decentralized!
 :: Smaller pools also often have smaller fees/payout limits.
 
-cd %~dp0
+cd /d "%~dp0"
 :: Use this command line to connect to non-SSL port
 xmrig.exe -a gr -o raptoreumemporium.com:3008 -u WALLET_ADDRESS -p x
 :: Or use this command line to connect to an SSL port

--- a/scripts/solo_mine_example.cmd
+++ b/scripts/solo_mine_example.cmd
@@ -11,6 +11,6 @@
 :: Mining solo is the best way to help Monero network be more decentralized!
 :: But you will only get a payout when you find a block which can take more than a year for a single low-end PC.
 
-cd %~dp0
+cd /d "%~dp0"
 xmrig.exe -o node.xmr.to:18081 -a rx/0 -u 48edfHu7V9Z84YzzMa6fUueoELZ9ZRXq9VetWzYGzKt52XU5xvqgzYnDK9URnRoJMk1j8nLwEVsaSWJ4fhdUyZijBGUicoD --daemon
 pause


### PR DESCRIPTION
This is a re-do of what was #3239 but against `dev` branch.

### Problem

When using a shortcut on C: drive that points to an xmrig script on another drive (ex. D:), and the shortcut is run as Administrator, the resulting script reports xmrig.exe not found.

### Example scenario

- Shortcut file: `C:\Users\name\Desktop\xmrig.lnk`
- "Target" field in the shortcut points to `D:\xmrig\benchmark_1M.cmd`
- Right-click on desktop shortcut, choose Run as administrator
- Result: `'xmrig.exe' is not recognized as an internal or external command, operable program or batch file.`

### Fix/workaround

As of Windows 10 (possibly 8), you cannot work around this problem using the "Start in" field of shortcuts; it isn't honoured when things are run as Administrator.  This is intentional on Microsoft's part, citing some security-related concern.  Debating this is outside the scope of this PR.  You can Google things like `windows "start in" C:\windows\system32 administrator` and read about it yourself, but https://github.com/microsoft/terminal/issues/7062 talks about it in detail.

Therefore, the proper workaround is use `cd /d` which changes drive letters when given a full path that includes drive letters (which `%~dp0` always does).

This flag has existed since at least Windows 7 (unsure about Vista, XP, or 2K).

Additionally, use double-quotes around `%~dp0` in the case there are spaces anywhere in the pathname.  Refer to the `cd /?` documentation for details about this; it's best to do it because we can't guarantee Command Extensions haven't been turned off by a user.

### Demonstrating the problem and fix:

- Shortcut file: `C:\Users\name\Desktop\test.lnk`
- "Target" points to `D:\xmrig\test.cmd`
- `D:\xmrig\test.cmd` contents:

```
@echo off
echo cwd 1: %cd%
cd %~dp0
echo cwd 2: %cd%
cd /d "%~dp0"
echo cwd 3: %cd%
pause
```

- Right-click on desktop shortcut, choose Run as administrator
- Results are below -- cwd 2 might surprise you:

```
cwd 1: C:\Windows\system32
cwd 2: C:\Windows\system32
cwd 3: D:\xmrig
Press any key to continue . . .
```
