### PR TITLE
Fix warning about unused variable

### DIFF
--- a/src/hw/dmi/DmiReader.cpp
+++ b/src/hw/dmi/DmiReader.cpp
@@ -88,7 +88,6 @@ bool xmrig::DmiReader::decode(uint8_t *buf)
     }
 
     uint8_t *data = buf;
-    int i         = 0;
 
     while (data + 4 <= buf + m_size) {
         dmi_header h{};
@@ -97,7 +96,6 @@ bool xmrig::DmiReader::decode(uint8_t *buf)
         if (h.length < 4 || h.type == 127) {
             break;
         }
-        i++;
 
         uint8_t *next = data + h.length;
         while (static_cast<uint32_t>(next - buf + 1) < m_size && (next[0] != 0 || next[1] != 0)) {


### PR DESCRIPTION
It's a cosmetic change. The variable is only modified, but its value never used.