### PR TITLE
Added SNI option for TLS connections

### DIFF
--- a/src/base/net/stratum/Client.cpp
+++ b/src/base/net/stratum/Client.cpp
@@ -589,7 +589,7 @@ void xmrig::Client::handshake()
     if (isTLS()) {
         m_expire = Chrono::steadyMSecs() + kResponseTimeout;
 
-        m_tls->handshake();
+        m_tls->handshake(m_pool.isSNI() ? m_pool.host().data() : nullptr);
     }
     else
 #   endif

--- a/src/base/net/stratum/Pool.cpp
+++ b/src/base/net/stratum/Pool.cpp
@@ -77,6 +77,7 @@ const char *Pool::kSelfSelect             = "self-select";
 const char *Pool::kSOCKS5                 = "socks5";
 const char *Pool::kSubmitToOrigin         = "submit-to-origin";
 const char *Pool::kTls                    = "tls";
+const char *Pool::kSni                    = "sni";
 const char *Pool::kUrl                    = "url";
 const char *Pool::kUser                   = "user";
 const char *Pool::kSpendSecretKey         = "spend-secret-key";
@@ -137,6 +138,7 @@ xmrig::Pool::Pool(const rapidjson::Value &object) :
     m_flags.set(FLAG_ENABLED,  Json::getBool(object, kEnabled, true));
     m_flags.set(FLAG_NICEHASH, Json::getBool(object, kNicehash) || m_url.host().contains(kNicehashHost));
     m_flags.set(FLAG_TLS,      Json::getBool(object, kTls) || m_url.isTLS());
+    m_flags.set(FLAG_SNI,      Json::getBool(object, kSni));
 
     setKeepAlive(Json::getValue(object, kKeepalive));
 
@@ -299,6 +301,7 @@ rapidjson::Value xmrig::Pool::toJSON(rapidjson::Document &doc) const
 
     obj.AddMember(StringRef(kEnabled),      m_flags.test(FLAG_ENABLED), allocator);
     obj.AddMember(StringRef(kTls),          isTLS(), allocator);
+    obj.AddMember(StringRef(kSni),          isSNI(), allocator);
     obj.AddMember(StringRef(kFingerprint),  m_fingerprint.toJSON(), allocator);
     obj.AddMember(StringRef(kDaemon),       m_mode == MODE_DAEMON, allocator);
     obj.AddMember(StringRef(kSOCKS5),       m_proxy.toJSON(doc), allocator);

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -70,6 +70,7 @@ public:
     static const char *kSOCKS5;
     static const char *kSubmitToOrigin;
     static const char *kTls;
+    static const char* kSni;
     static const char *kUrl;
     static const char *kUser;
     static const char* kSpendSecretKey;
@@ -95,6 +96,7 @@ public:
 
     inline bool isNicehash() const                      { return m_flags.test(FLAG_NICEHASH); }
     inline bool isTLS() const                           { return m_flags.test(FLAG_TLS) || m_url.isTLS(); }
+    inline bool isSNI() const                           { return m_flags.test(FLAG_SNI); }
     inline bool isValid() const                         { return m_url.isValid(); }
     inline const Algorithm &algorithm() const           { return m_algorithm; }
     inline const Coin &coin() const                     { return m_coin; }
@@ -138,6 +140,7 @@ private:
         FLAG_ENABLED,
         FLAG_NICEHASH,
         FLAG_TLS,
+        FLAG_SNI,
         FLAG_MAX
     };
 

--- a/src/base/net/stratum/Tls.cpp
+++ b/src/base/net/stratum/Tls.cpp
@@ -60,13 +60,17 @@ xmrig::Client::Tls::~Tls()
 }
 
 
-bool xmrig::Client::Tls::handshake()
+bool xmrig::Client::Tls::handshake(const char* servername)
 {
     m_ssl = SSL_new(m_ctx);
     assert(m_ssl != nullptr);
 
     if (!m_ssl) {
         return false;
+    }
+
+    if (servername) {
+        SSL_set_tlsext_host_name(m_ssl, servername);
     }
 
     SSL_set_connect_state(m_ssl);

--- a/src/base/net/stratum/Tls.h
+++ b/src/base/net/stratum/Tls.h
@@ -42,7 +42,7 @@ public:
     Tls(Client *client);
     ~Tls();
 
-    bool handshake();
+    bool handshake(const char* servername);
     bool send(const char *data, size_t size);
     const char *fingerprint() const;
     const char *version() const;


### PR DESCRIPTION
Disabled by default, add `"sni": true,` to pool config to enable it.