### PR TITLE
add support for townforge (monero fork using randomx)

### DIFF
--- a/src/base/crypto/Coin.cpp
+++ b/src/base/crypto/Coin.cpp
@@ -54,6 +54,7 @@ static const CoinInfo coinInfo[] = {
     { Algorithm::KAWPOW_RVN,      "RVN",      "Ravencoin",    0,      0,              BLUE_BG_BOLD(   WHITE_BOLD_S " raven   ") },
     { Algorithm::RX_WOW,          "WOW",      "Wownero",      300,    100000000000,   MAGENTA_BG_BOLD(WHITE_BOLD_S " wownero ") },
     { Algorithm::RX_0,            "ZEPH",     "Zephyr",       120,    1000000000000,  BLUE_BG_BOLD(   WHITE_BOLD_S " zephyr  ") },
+    { Algorithm::RX_0,            "Townforge","Townforge",    30,     100000000,      MAGENTA_BG_BOLD(WHITE_BOLD_S " townforge ") },
 };
 
 

--- a/src/base/crypto/Coin.h
+++ b/src/base/crypto/Coin.h
@@ -40,6 +40,7 @@ public:
         RAVEN,
         WOWNERO,
         ZEPHYR,
+        TOWNFORGE,
         MAX
     };
 

--- a/src/base/tools/cryptonote/BlockTemplate.cpp
+++ b/src/base/tools/cryptonote/BlockTemplate.cpp
@@ -207,7 +207,8 @@ bool xmrig::BlockTemplate::parse(bool hashes)
     setOffset(MINER_TX_PREFIX_OFFSET, ar.index());
 
     ar(m_txVersion);
-    ar(m_unlockTime);
+    if (m_coin != Coin::TOWNFORGE)
+      ar(m_unlockTime);
     ar(m_numInputs);
 
     // must be 1 input
@@ -280,6 +281,9 @@ bool xmrig::BlockTemplate::parse(bool hashes)
         ar(m_viewTag);
     }
 
+    if (m_coin == Coin::TOWNFORGE)
+      ar(m_unlockTime);
+
     ar(m_extraSize);
 
     setOffset(TX_EXTRA_OFFSET, ar.index());
@@ -334,6 +338,10 @@ bool xmrig::BlockTemplate::parse(bool hashes)
     // RCT signatures (empty in miner transaction)
     uint8_t vin_rct_type = 0;
     ar(vin_rct_type);
+
+    // no way I'm parsing a full game update here
+    if (m_coin == Coin::TOWNFORGE && m_height % 720 == 0)
+      return true;
 
     // must be RCTTypeNull (0)
     if (vin_rct_type != 0) {


### PR DESCRIPTION
xmrig is unable to mine townforge due to failing address validation.

Maybe it should leave this to the daemon, which surely knows better.