### PR TITLE
RandomX: correct memcpy size for JIT initialization

### DIFF
--- a/src/crypto/randomx/jit_compiler_a64.cpp
+++ b/src/crypto/randomx/jit_compiler_a64.cpp
@@ -1078,6 +1078,6 @@ void JitCompilerA64::h_NOP(Instruction& instr, uint32_t& codePos)
 {
 }
 
-InstructionGeneratorA64 JitCompilerA64::engine[257] = {};
+InstructionGeneratorA64 JitCompilerA64::engine[256] = {};
 
 }

--- a/src/crypto/randomx/jit_compiler_a64.hpp
+++ b/src/crypto/randomx/jit_compiler_a64.hpp
@@ -74,7 +74,7 @@ namespace randomx {
 		void enableWriting() const;
 		void enableExecution() const;
 
-		static InstructionGeneratorA64 engine[257];
+		static InstructionGeneratorA64 engine[256];
 
 	private:
 		const bool hugePages;

--- a/src/crypto/randomx/jit_compiler_x86.cpp
+++ b/src/crypto/randomx/jit_compiler_x86.cpp
@@ -1443,6 +1443,6 @@ namespace randomx {
 		emitByte(0x90, code, codePos);
 	}
 
-	alignas(64) InstructionGeneratorX86 JitCompilerX86::engine[257] = {};
+	alignas(64) InstructionGeneratorX86 JitCompilerX86::engine[256] = {};
 
 }

--- a/src/crypto/randomx/jit_compiler_x86.hpp
+++ b/src/crypto/randomx/jit_compiler_x86.hpp
@@ -81,7 +81,7 @@ namespace randomx {
 		void enableWriting() const;
 		void enableExecution() const;
 
-		alignas(64) static InstructionGeneratorX86 engine[257];
+		alignas(64) static InstructionGeneratorX86 engine[256];
 
 	private:
 		int registerUsage[RegistersCount] = {};

--- a/src/crypto/randomx/randomx.cpp
+++ b/src/crypto/randomx/randomx.cpp
@@ -260,8 +260,7 @@ typedef void(randomx::JitCompilerX86::* InstructionGeneratorX86_2)(const randomx
 
 #define JIT_HANDLE(x, prev) do { \
 		const InstructionGeneratorX86_2 p = &randomx::JitCompilerX86::h_##x; \
-		static_assert(sizeof(p) == sizeof(randomx::JitCompilerX86::engine[k]), "Pointer size mismatch"); \
-		memcpy(randomx::JitCompilerX86::engine + k, &p, sizeof(p)); \
+		memcpy(randomx::JitCompilerX86::engine + k, &p, sizeof(randomx::JitCompilerX86::engine[k])); \
 	} while (0)
 
 #elif (XMRIG_ARM == 8)


### PR DESCRIPTION
No buffer overflow, better fix for `_FORTIFY_SOURCE`. Replaces #3450 and #3461.