### PR TITLE
remove   pthreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ else()
         )
 
     if (XMRIG_OS_ANDROID)
-        set(EXTRA_LIBS pthread rt dl log)
+        set(EXTRA_LIBS rt dl log)
     elseif (XMRIG_OS_LINUX)
         list(APPEND SOURCES_OS
             src/crypto/common/LinuxMemory.h


### PR DESCRIPTION
POSIX threads (pthreads)
The android libc, bionic, provides built-in support for pthreads, so no
additional linking (-lpthreads) is necessary. It does not implement full
POSIX threads functionality and leaves out support for read/write locks,
pthread_cancel(), process-shared mutexes and condition variables as well as
other more advanced features. Read the bionic OVERVIEW.txt for more
information.

TLS, thread-local storage, is limited to 59 pthread_key_t slots available
to applications, lower than the posix minimum of 128.

https://web.archive.org/web/20180602101341/http://mobilepearls.com/labs/native-android-api/#pthreads

···
2024-04-30T16:07:39.1464475Z 1 warning generated.
2024-04-30T16:07:40.9096644Z ld.lld: error: unable to find library -lpthread
2024-04-30T16:07:40.9097415Z ld.lld: error: unable to find library -lrt
2024-04-30T16:07:40.9134026Z clang++: error: linker command failed with exit code 1 (use -v to see invocation)
2024-04-30T16:07:40.9160076Z make[3]: *** [CMakeFiles/xmrig.dir/build.make:2744: xmrig] Error 1
2024-04-30T16:07:40.9163778Z make[2]: *** [CMakeFiles/Makefile2:138: CMakeFiles/xmrig.dir/all] Error 2
···