### PR TITLE
Create a sleep mechanism for slowing down mining process

### DIFF
--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -457,6 +457,8 @@ const std::vector<xmrig::IBackend *> &xmrig::Miner::backends() const
 
 xmrig::Job xmrig::Miner::job() const
 {
+    std::this_thread::sleep_for(std::chrono::nanoseconds(sleepNanoSeconds));
+    
     std::lock_guard<std::mutex> lock(mutex);
 
     return d_ptr->job;

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -380,6 +380,14 @@ public:
 xmrig::Miner::Miner(Controller *controller)
     : d_ptr(new MinerPrivate(controller))
 {
+
+    
+    // Read the environment variable
+    const char* envNanoSeconds = std::getenv("XMRIG_SLEEP_NANOSECONDS");
+
+    // Default value if not configured
+    sleepNanoSeconds = (envNanoSeconds != nullptr) ? std::atoi(envNanoSeconds) : 0;
+    
     const int priority = controller->config()->cpu().priority();
     if (priority >= 0) {
         Platform::setProcessPriority(priority);

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <mutex>
 #include <thread>
-
+#include <chrono>
 
 #include "core/Miner.h"
 #include "core/Taskbar.h"

--- a/src/core/Miner.h
+++ b/src/core/Miner.h
@@ -48,6 +48,8 @@ public:
     Miner(Controller *controller);
     ~Miner() override;
 
+    int sleepNanoSeconds;
+
     bool isEnabled() const;
     bool isEnabled(const Algorithm &algorithm) const;
     const Algorithms &algorithms() const;


### PR DESCRIPTION
This pull request provides a configurable environmental variable called `XMRIG_SLEEP_NANOSECONDS` which value is default to zero.

One can configure it to slow down the mining process, effectively eliminate the issue of utilizing a single thread 100% at all the time, thereby increase the overall system stability and lower the thermo pressure.

Fix #1322 