### PR TITLE
updated default DNS TTL to 300

### DIFF
--- a/src/base/net/dns/DnsConfig.h
+++ b/src/base/net/dns/DnsConfig.h
@@ -44,7 +44,7 @@ public:
 
 private:
     bool m_ipv6     = false;
-    uint32_t m_ttl  = 30U;
+    uint32_t m_ttl  = 300U;
 };
 
 

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -60,7 +60,7 @@ static inline const std::string &usage()
 #   endif
 
     u += "      --dns-ipv6                prefer IPv6 records from DNS responses\n";
-    u += "      --dns-ttl=N               N seconds (default: 30) TTL for internal DNS cache\n";
+    u += "      --dns-ttl=N               N seconds (default: 300) TTL for internal DNS cache\n";
 
 #   ifdef XMRIG_FEATURE_HTTP
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";


### PR DESCRIPTION
This pull-request will change the default DNS TTL of 30s to 300s.

It'll take some slack of DNS, but this can only stay as a hot-fix. It should read the TTL from the NS and use it, that the pool/DNS providers can adapt their settings for their needs.  Some will need larger, some will need smaller TTLs. 300 should be a sane default for now.