### PR TITLE
Call `uv_loop_fork` to redecorate the default loop after `fork()`

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -61,12 +61,12 @@ int xmrig::App::exec()
         return 2;
     }
 
-    m_signals = std::make_shared<Signals>(this);
-
     int rc = 0;
     if (background(rc)) {
         return rc;
     }
+
+    m_signals = std::make_shared<Signals>(this);
 
     rc = m_controller->init();
     if (rc != 0) {

--- a/src/App_unix.cpp
+++ b/src/App_unix.cpp
@@ -27,6 +27,7 @@
 #include <csignal>
 #include <cerrno>
 #include <unistd.h>
+#include <uv.h>
 
 
 #include "App.h"
@@ -52,6 +53,8 @@ bool xmrig::App::background(int &rc)
 
         return true;
     }
+
+    uv_loop_fork(uv_default_loop());
 
     i = setsid();
 


### PR DESCRIPTION
Fixes #3455 

[libuv docs](https://docs.libuv.org/en/v1.x/loop.html#c.uv_loop_fork) basically say avoid using `fork()`, but if it must be done then you have to use this experimental function to fixup some things in the child, unless you make new loops (aka not use the default loop at all post-fork).