### PR TITLE
Throw away any existing uv_default_loop, recreate after fork

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -61,12 +61,13 @@ int xmrig::App::exec()
         return 2;
     }
 
-    m_signals = std::make_shared<Signals>(this);
-
     int rc = 0;
     if (background(rc)) {
         return rc;
     }
+
+    uv_loop_close(uv_default_loop());
+    m_signals = std::make_shared<Signals>(this);
 
     rc = m_controller->init();
     if (rc != 0) {

--- a/src/App.h
+++ b/src/App.h
@@ -33,6 +33,7 @@
 
 
 #include <memory>
+#include <uv.h>
 
 
 namespace xmrig {


### PR DESCRIPTION
(also) Fixes #3455 

This is an alternate approach to the problem, it does not function any differently however might be cleaner.  Simply destroy any existing default loop to cause a new one to be created on the next `uv_default_loop()` call (in Signals constructor).  This completely avoids using the experimental/non-guaranteed `uv_loop_fork()` function.