### PR TITLE
CpuBackend/setJob: do not return early for same-threads if the algo is different

### DIFF
--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -352,7 +352,7 @@ void xmrig::CpuBackend::setJob(const Job &job)
     const auto &cpu = d_ptr->controller->config()->cpu();
 
     auto threads = cpu.get(d_ptr->controller->miner(), job.algorithm());
-    if (!d_ptr->threads.empty() && d_ptr->threads.size() == threads.size() && std::equal(d_ptr->threads.begin(), d_ptr->threads.end(), threads.begin())) {
+    if (!d_ptr->threads.empty() && d_ptr->threads.size() == threads.size() && std::equal(d_ptr->threads.begin(), d_ptr->threads.end(), threads.begin()) && d_ptr->algo == job.algorithm()) {
         return;
     }
 


### PR DESCRIPTION
Occasionally under some conditions autoswitching would not stop/start between algos which also didn't reset the running hashrate averages

Unclear if it also would cause some other stale states, but the hashrates were the most noticeable side effect.

This would only occur if different algos had the same thread profile, and also didn't trigger an RX-flavor dataset recalc or GhostRider init.