### PR TITLE
Always reset nonce on RandomX dataset change

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -359,7 +359,9 @@ void xmrig::CpuWorker<N>::start()
             }
         }
 
-        consumeJob();
+        if (!Nonce::isPaused()) {
+            consumeJob();
+        }
     }
 }
 

--- a/src/backend/cuda/CudaWorker.cpp
+++ b/src/backend/cuda/CudaWorker.cpp
@@ -158,7 +158,7 @@ void xmrig::CudaWorker::start()
             std::this_thread::yield();
         }
 
-        if (!consumeJob()) {
+        if (isReady() && !consumeJob()) {
             return;
         }
     }

--- a/src/backend/opencl/OclWorker.cpp
+++ b/src/backend/opencl/OclWorker.cpp
@@ -190,7 +190,7 @@ void xmrig::OclWorker::start()
             std::this_thread::yield();
         }
 
-        if (!consumeJob()) {
+        if (isReady() && !consumeJob()) {
             return;
         }
     }

--- a/src/core/Miner.cpp
+++ b/src/core/Miner.cpp
@@ -576,6 +576,11 @@ void xmrig::Miner::setJob(const Job &job, bool donate)
 
 #   ifdef XMRIG_ALGO_RANDOMX
     const bool ready = d_ptr->initRX();
+
+    // Always reset nonce on RandomX dataset change
+    if (!ready) {
+        d_ptr->reset = true;
+    }
 #   else
     constexpr const bool ready = true;
 #   endif


### PR DESCRIPTION
Also never get a new job when mining is paused.

Possible fix for #3404