### PR TITLE
Optimized autoconfig for AMD CPUs with < 2 MB L3 cache per thread

### DIFF
--- a/src/backend/cpu/platform/HwlocCpuInfo.cpp
+++ b/src/backend/cpu/platform/HwlocCpuInfo.cpp
@@ -320,8 +320,13 @@ void xmrig::HwlocCpuInfo::processTopLevelCache(hwloc_obj_t cache, const Algorith
             L2 += l2->attr->cache.size;
             L2_associativity = l2->attr->cache.associativity;
 
-            if (L3_exclusive && l2->attr->cache.size >= scratchpad) {
-                extra += scratchpad;
+            if (L3_exclusive) {
+                if (vendor() == VENDOR_AMD) {
+                    extra += std::min<size_t>(l2->attr->cache.size, scratchpad);
+                }
+                else if (l2->attr->cache.size >= scratchpad) {
+                    extra += scratchpad;
+                }
             }
         }
     }


### PR DESCRIPTION
Before: https://xmrig.com/benchmark/6LiHex (6897 h/s)
After: https://xmrig.com/benchmark/2TG82a (7504 h/s)