### PR TITLE
Tweaked autoconfig for AMD CPUs with < 2 MB L3 cache per thread

### DIFF
--- a/src/backend/cpu/platform/HwlocCpuInfo.cpp
+++ b/src/backend/cpu/platform/HwlocCpuInfo.cpp
@@ -322,7 +322,8 @@ void xmrig::HwlocCpuInfo::processTopLevelCache(hwloc_obj_t cache, const Algorith
 
             if (L3_exclusive) {
                 if (vendor() == VENDOR_AMD) {
-                    extra += std::min<size_t>(l2->attr->cache.size, scratchpad);
+                    // For some reason, AMD CPUs can use only half of the exclusive L2/L3 cache combo efficiently
+                    extra += std::min<size_t>(l2->attr->cache.size / 2, scratchpad);
                 }
                 else if (l2->attr->cache.size >= scratchpad) {
                     extra += scratchpad;


### PR DESCRIPTION
For some reason, AMD CPUs can use only half of the exclusive L2/L3 cache combo efficiently.
Tested on Ryzen 5 8600G:

|Version|Hashrate | Threads used
|-|-|-|
|XMRig v6.22.2 | 6100 h/s | 8
|XMRig v6.22.3 | 5980 h/s | 11
|XMRig v6.22.3 with this fix | 6250 h/s | 9