### PR TITLE
Improved IPv6 support.

### DIFF
--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -18,13 +18,11 @@
 
 #include <cstdio>
 
-
 #ifdef _MSC_VER
 #   include "getopt/getopt.h"
 #else
 #   include <getopt.h>
 #endif
-
 
 #include "base/kernel/config/BaseTransform.h"
 #include "base/io/json/JsonChain.h"
@@ -37,7 +35,6 @@
 #include "base/net/stratum/Pools.h"
 #include "core/config/Config_platform.h"
 
-
 #ifdef XMRIG_FEATURE_TLS
 #   include "base/net/tls/TlsConfig.h"
 #endif
@@ -47,9 +44,9 @@ void xmrig::BaseTransform::load(JsonChain &chain, Process *process, IConfigTrans
 {
     using namespace rapidjson;
 
-    int key     = 0;
-    int argc    = process->arguments().argc();
-    char **argv = process->arguments().argv();
+    int key        = 0;
+    const int argc = process->arguments().argc();
+    char **argv    = process->arguments().argv();
 
     Document doc(kObjectType);
 
@@ -262,7 +259,8 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::DaemonKey:      /* --daemon */
     case IConfig::SubmitToOriginKey: /* --submit-to-origin */
     case IConfig::VerboseKey:     /* --verbose */
-    case IConfig::DnsIPv6Key:     /* --dns-ipv6 */
+    case IConfig::DnsIPv4Key:     /* --ipv4 */
+    case IConfig::DnsIPv6Key:     /* --ipv6 */
         return transformBoolean(doc, key, true);
 
     case IConfig::ColorKey:          /* --no-color */
@@ -323,8 +321,11 @@ void xmrig::BaseTransform::transformBoolean(rapidjson::Document &doc, int key, b
     case IConfig::NoTitleKey: /* --no-title */
         return set(doc, BaseConfig::kTitle, enable);
 
-    case IConfig::DnsIPv6Key: /* --dns-ipv6 */
-        return set(doc, DnsConfig::kField, DnsConfig::kIPv6, enable);
+    case IConfig::DnsIPv4Key: /* --ipv4 */
+        return set(doc, DnsConfig::kField, DnsConfig::kIPv, 4);
+
+    case IConfig::DnsIPv6Key: /* --ipv6 */
+        return set(doc, DnsConfig::kField, DnsConfig::kIPv, 6);
 
     default:
         break;

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,9 +16,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_ICONFIG_H
-#define XMRIG_ICONFIG_H
-
+#pragma once
 
 #include "3rdparty/rapidjson/fwd.h"
 
@@ -82,7 +80,8 @@ public:
         HugePageSizeKey      = 1050,
         PauseOnActiveKey     = 1051,
         SubmitToOriginKey    = 1052,
-        DnsIPv6Key           = 1053,
+        DnsIPv4Key           = '4',
+        DnsIPv6Key           = '6',
         DnsTtlKey            = 1054,
         SpendSecretKey       = 1055,
         DaemonZMQPortKey     = 1056,
@@ -177,7 +176,4 @@ public:
 };
 
 
-} /* namespace xmrig */
-
-
-#endif // XMRIG_ICONFIG_H
+} // namespace xmrig

--- a/src/base/kernel/interfaces/IDnsBackend.h
+++ b/src/base/kernel/interfaces/IDnsBackend.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,21 +16,16 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_IDNSBACKEND_H
-#define XMRIG_IDNSBACKEND_H
-
+#pragma once
 
 #include "base/tools/Object.h"
-
-
-#include <memory>
 
 
 namespace xmrig {
 
 
+class DnsConfig;
 class DnsRecords;
-class DnsRequest;
 class IDnsListener;
 class String;
 
@@ -43,12 +38,9 @@ public:
     IDnsBackend()           = default;
     virtual ~IDnsBackend()  = default;
 
-    virtual const DnsRecords &records() const                                                               = 0;
-    virtual std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl)   = 0;
+    virtual const DnsRecords &records() const                                                                       = 0;
+    virtual void resolve(const String &host, const std::weak_ptr<IDnsListener> &listener, const DnsConfig &config)  = 0;
 };
 
 
-} /* namespace xmrig */
-
-
-#endif // XMRIG_IDNSBACKEND_H
+} // namespace xmrig

--- a/src/base/net/dns/Dns.cpp
+++ b/src/base/net/dns/Dns.cpp
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 
 #include "base/net/dns/Dns.h"
+#include "base/net/dns/DnsRequest.h"
 #include "base/net/dns/DnsUvBackend.h"
 
 
@@ -25,17 +26,21 @@ namespace xmrig {
 
 
 DnsConfig Dns::m_config;
-std::map<String, std::shared_ptr<IDnsBackend> > Dns::m_backends;
+std::map<String, std::shared_ptr<IDnsBackend>> Dns::m_backends;
 
 
 } // namespace xmrig
 
 
-std::shared_ptr<xmrig::DnsRequest> xmrig::Dns::resolve(const String &host, IDnsListener *listener, uint64_t ttl)
+std::shared_ptr<xmrig::DnsRequest> xmrig::Dns::resolve(const String &host, IDnsListener *listener)
 {
+    auto req = std::make_shared<DnsRequest>(listener);
+
     if (m_backends.find(host) == m_backends.end()) {
         m_backends.insert({ host, std::make_shared<DnsUvBackend>() });
     }
 
-    return m_backends.at(host)->resolve(host, listener, ttl == 0 ? m_config.ttl() : ttl);
+    m_backends.at(host)->resolve(host, req, m_config);
+
+    return req;
 }

--- a/src/base/net/dns/Dns.h
+++ b/src/base/net/dns/Dns.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -43,7 +43,7 @@ public:
     inline static const DnsConfig &config()             { return m_config; }
     inline static void set(const DnsConfig &config)     { m_config = config; }
 
-    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl = 0);
+    static std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener);
 
 private:
     static DnsConfig m_config;

--- a/src/base/net/dns/DnsConfig.h
+++ b/src/base/net/dns/DnsConfig.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,9 +16,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNSCONFIG_H
-#define XMRIG_DNSCONFIG_H
-
+#pragma once
 
 #include "3rdparty/rapidjson/fwd.h"
 
@@ -30,25 +28,22 @@ class DnsConfig
 {
 public:
     static const char *kField;
-    static const char *kIPv6;
+    static const char *kIPv;
     static const char *kTTL;
 
     DnsConfig() = default;
     DnsConfig(const rapidjson::Value &value);
 
-    inline bool isIPv6() const  { return m_ipv6; }
+    inline uint32_t ipv() const { return m_ipv; }
     inline uint32_t ttl() const { return m_ttl * 1000U; }
 
+    int ai_family() const;
     rapidjson::Value toJSON(rapidjson::Document &doc) const;
 
-
 private:
-    bool m_ipv6     = false;
-    uint32_t m_ttl  = 30U;
+    uint32_t m_ttl = 30U;
+    uint32_t m_ipv = 0U;
 };
 
 
-} /* namespace xmrig */
-
-
-#endif /* XMRIG_DNSCONFIG_H */
+} // namespace xmrig

--- a/src/base/net/dns/DnsRecord.cpp
+++ b/src/base/net/dns/DnsRecord.cpp
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2023 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2023 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,19 +16,16 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include <uv.h>
-
 
 #include "base/net/dns/DnsRecord.h"
 
 
-xmrig::DnsRecord::DnsRecord(const addrinfo *addr) :
-    m_type(addr->ai_family == AF_INET6 ? AAAA : (addr->ai_family == AF_INET ? A : Unknown))
+xmrig::DnsRecord::DnsRecord(const addrinfo *addr)
 {
     static_assert(sizeof(m_data) >= sizeof(sockaddr_in6), "Not enough storage for IPv6 address.");
 
-    memcpy(m_data, addr->ai_addr, m_type == AAAA ? sizeof(sockaddr_in6) : sizeof(sockaddr_in));
+    memcpy(m_data, addr->ai_addr, addr->ai_family == AF_INET6 ? sizeof(sockaddr_in6) : sizeof(sockaddr_in));
 }
 
 
@@ -44,7 +41,7 @@ xmrig::String xmrig::DnsRecord::ip() const
 {
     char *buf = nullptr;
 
-    if (m_type == AAAA) {
+    if (reinterpret_cast<const sockaddr &>(m_data).sa_family == AF_INET6) {
         buf = new char[45]();
         uv_ip6_name(reinterpret_cast<const sockaddr_in6*>(m_data), buf, 45);
     }

--- a/src/base/net/dns/DnsRecord.h
+++ b/src/base/net/dns/DnsRecord.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,13 +16,10 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNSRECORD_H
-#define XMRIG_DNSRECORD_H
-
+#pragma once
 
 struct addrinfo;
 struct sockaddr;
-
 
 #include "base/tools/String.h"
 
@@ -33,28 +30,15 @@ namespace xmrig {
 class DnsRecord
 {
 public:
-    enum Type : uint32_t {
-        Unknown,
-        A,
-        AAAA
-    };
-
     DnsRecord() {}
     DnsRecord(const addrinfo *addr);
 
     const sockaddr *addr(uint16_t port = 0) const;
     String ip() const;
 
-    inline bool isValid() const     { return m_type != Unknown; }
-    inline Type type() const        { return m_type; }
-
 private:
     mutable uint8_t m_data[28]{};
-    const Type m_type = Unknown;
 };
 
 
-} /* namespace xmrig */
-
-
-#endif /* XMRIG_DNSRECORD_H */
+} // namespace xmrig

--- a/src/base/net/dns/DnsRecords.h
+++ b/src/base/net/dns/DnsRecords.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,9 +16,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNSRECORDS_H
-#define XMRIG_DNSRECORDS_H
-
+#pragma once
 
 #include "base/net/dns/DnsRecord.h"
 
@@ -29,20 +27,19 @@ namespace xmrig {
 class DnsRecords
 {
 public:
-    inline bool isEmpty() const       { return m_ipv4.empty() && m_ipv6.empty(); }
+    DnsRecords() = default;
+    DnsRecords(const addrinfo *res, int ai_family);
 
-    const DnsRecord &get(DnsRecord::Type prefered = DnsRecord::Unknown) const;
-    size_t count(DnsRecord::Type type = DnsRecord::Unknown) const;
-    void clear();
-    void parse(addrinfo *res);
+    inline bool isEmpty() const                             { return m_records.empty(); }
+    inline const std::vector<DnsRecord> &records() const    { return m_records; }
+    inline size_t size() const                              { return m_records.size(); }
+
+    const DnsRecord &get() const;
 
 private:
-    std::vector<DnsRecord> m_ipv4;
-    std::vector<DnsRecord> m_ipv6;
+    mutable size_t m_index = 0;
+    std::vector<DnsRecord> m_records;
 };
 
 
-} /* namespace xmrig */
-
-
-#endif /* XMRIG_DNSRECORDS_H */
+} // namespace xmrig

--- a/src/base/net/dns/DnsRequest.h
+++ b/src/base/net/dns/DnsRequest.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,35 +16,30 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNSREQUEST_H
-#define XMRIG_DNSREQUEST_H
+#pragma once
 
-
-#include "base/tools/Object.h"
-
-
-#include <cstdint>
+#include "base/kernel/interfaces/IDnsListener.h"
 
 
 namespace xmrig {
 
 
-class IDnsListener;
-
-
-class DnsRequest
+class DnsRequest : public IDnsListener
 {
 public:
     XMRIG_DISABLE_COPY_MOVE_DEFAULT(DnsRequest)
 
-    DnsRequest(IDnsListener *listener) : listener(listener) {}
-    ~DnsRequest() = default;
+    inline DnsRequest(IDnsListener *listener) : m_listener(listener) {}
+    ~DnsRequest() override = default;
 
-    IDnsListener *listener;
+protected:
+    inline void onResolved(const DnsRecords &records, int status, const char *error) override {
+        m_listener->onResolved(records, status, error);
+    }
+
+private:
+    IDnsListener *m_listener;
 };
 
 
-} /* namespace xmrig */
-
-
-#endif /* XMRIG_DNSREQUEST_H */
+} // namespace xmrig

--- a/src/base/net/dns/DnsUvBackend.h
+++ b/src/base/net/dns/DnsUvBackend.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,16 +16,13 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_DNSUVBACKEND_H
-#define XMRIG_DNSUVBACKEND_H
-
+#pragma once
 
 #include "base/kernel/interfaces/IDnsBackend.h"
 #include "base/net/dns/DnsRecords.h"
 #include "base/net/tools/Storage.h"
 
-
-#include <queue>
+#include <deque>
 
 
 using uv_getaddrinfo_t = struct uv_getaddrinfo_s;
@@ -45,18 +42,19 @@ public:
 protected:
     inline const DnsRecords &records() const override   { return m_records; }
 
-    std::shared_ptr<DnsRequest> resolve(const String &host, IDnsListener *listener, uint64_t ttl) override;
+    void resolve(const String &host, const std::weak_ptr<IDnsListener> &listener, const DnsConfig &config) override;
 
 private:
     bool resolve(const String &host);
-    void done();
+    void notify();
     void onResolved(int status, addrinfo *res);
 
     static void onResolved(uv_getaddrinfo_t *req, int status, addrinfo *res);
 
     DnsRecords m_records;
+    int m_ai_family         = 0;
     int m_status            = 0;
-    std::queue<std::weak_ptr<DnsRequest> > m_queue;
+    std::deque<std::weak_ptr<IDnsListener>> m_queue;
     std::shared_ptr<uv_getaddrinfo_t> m_req;
     uint64_t m_ts           = 0;
     uintptr_t m_key;
@@ -66,7 +64,4 @@ private:
 };
 
 
-} /* namespace xmrig */
-
-
-#endif /* XMRIG_DNSUVBACKEND_H */
+} // namespace xmrig

--- a/src/config.json
+++ b/src/config.json
@@ -93,7 +93,7 @@
         "dhparam": null
     },
     "dns": {
-        "ipv6": false,
+        "ip_version": 0,
         "ttl": 30
     },
     "user-agent": null,

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -1,6 +1,6 @@
 /* XMRig
- * Copyright (c) 2018-2021 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2021 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -16,9 +16,7 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_CONFIG_PLATFORM_H
-#define XMRIG_CONFIG_PLATFORM_H
-
+#pragma once
 
 #ifdef _MSC_VER
 #   include "getopt/getopt.h"
@@ -28,13 +26,12 @@
 
 
 #include "base/kernel/interfaces/IConfig.h"
-#include "version.h"
 
 
 namespace xmrig {
 
 
-static const char short_options[] = "a:c:kBp:Px:r:R:s:t:T:o:u:O:v:l:Sx:";
+static const char short_options[] = "a:c:kBp:Px:r:R:s:t:T:o:u:O:v:l:Sx:46";
 
 
 static const option options[] = {
@@ -99,7 +96,8 @@ static const option options[] = {
     { "no-title",              0, nullptr, IConfig::NoTitleKey            },
     { "pause-on-battery",      0, nullptr, IConfig::PauseOnBatteryKey     },
     { "pause-on-active",       1, nullptr, IConfig::PauseOnActiveKey      },
-    { "dns-ipv6",              0, nullptr, IConfig::DnsIPv6Key            },
+    { "ipv4",                  0, nullptr, IConfig::DnsIPv4Key            },
+    { "ipv6",                  0, nullptr, IConfig::DnsIPv6Key            },
     { "dns-ttl",               1, nullptr, IConfig::DnsTtlKey             },
     { "spend-secret-key",      1, nullptr, IConfig::SpendSecretKey        },
 #   ifdef XMRIG_FEATURE_BENCHMARK
@@ -169,6 +167,3 @@ static const option options[] = {
 
 
 } // namespace xmrig
-
-
-#endif /* XMRIG_CONFIG_PLATFORM_H */

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -4,8 +4,8 @@
  * Copyright (c) 2014      Lucas Jones <https://github.com/lucasjones>
  * Copyright (c) 2014-2016 Wolf9466    <https://github.com/OhGodAPet>
  * Copyright (c) 2016      Jay D Dee   <jayddee246@gmail.com>
- * Copyright (c) 2018-2024 SChernykh   <https://github.com/SChernykh>
- * Copyright (c) 2016-2024 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ * Copyright (c) 2018-2025 SChernykh   <https://github.com/SChernykh>
+ * Copyright (c) 2016-2025 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -21,12 +21,9 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef XMRIG_USAGE_H
-#define XMRIG_USAGE_H
-
+#pragma once
 
 #include "version.h"
-
 
 #include <string>
 
@@ -59,7 +56,8 @@ static inline const std::string &usage()
     u += "      --tls-fingerprint=HEX     pool TLS certificate fingerprint for strict certificate pinning\n";
 #   endif
 
-    u += "      --dns-ipv6                prefer IPv6 records from DNS responses\n";
+    u += "  -4, --ipv4                    resolve names to IPv4 addresses\n";
+    u += "  -6, --ipv6                    resolve names to IPv6 addresses\n";
     u += "      --dns-ttl=N               N seconds (default: 30) TTL for internal DNS cache\n";
 
 #   ifdef XMRIG_FEATURE_HTTP
@@ -205,6 +203,4 @@ static inline const std::string &usage()
 }
 
 
-} /* namespace xmrig */
-
-#endif /* XMRIG_USAGE_H */
+} // namespace xmrig


### PR DESCRIPTION
The default behavior for DNS requests now treats IPv4 and IPv6 equally, with the option to prioritize one while failback to IPv4 if necessary.

Option `"ipv6"` in `"dns"` object replaced to `"ip_version"` with possible values: `4` (IPv4), `6` (IPv6), or `0` (no preference). Option `6` is not strict; if no IPv6 records are found, it will automatically fall back to IPv4. In contrast, option `4` is strict and will only use IPv4 records.

Command line option `--dns-ipv6` replaced to `-4, --ipv4` and `-6, --ipv6`.

Other improvements:
- If multiple addresses are received, they will be used sequentially, starting from a random address instead of being fully random before.
- DNS errors are cached too.