### PR TITLE
Fix undefined behavior in keccak.cpp

### DIFF
--- a/src/base/crypto/keccak.cpp
+++ b/src/base/crypto/keccak.cpp
@@ -166,6 +166,7 @@ void xmrig::keccakf(uint64_t st[25], int rounds)
 // compute a keccak hash (md) of given byte length from "in"
 typedef uint64_t state_t[25];
 
+typedef uint64_t uint64_t_alias __attribute__((__may_alias__));
 
 void xmrig::keccak(const uint8_t *in, int inlen, uint8_t *md, int mdlen)
 {
@@ -180,7 +181,7 @@ void xmrig::keccak(const uint8_t *in, int inlen, uint8_t *md, int mdlen)
 
     for ( ; inlen >= rsiz; inlen -= rsiz, in += rsiz) {
         for (i = 0; i < rsizw; i++) {
-            st[i] ^= ((uint64_t *) in)[i];
+            st[i] ^= ((uint64_t_alias *) in)[i];
         }
 
         xmrig::keccakf(st, KECCAK_ROUNDS);
@@ -193,7 +194,7 @@ void xmrig::keccak(const uint8_t *in, int inlen, uint8_t *md, int mdlen)
     temp[rsiz - 1] |= 0x80;
 
     for (i = 0; i < rsizw; i++) {
-        st[i] ^= ((uint64_t *) temp)[i];
+        st[i] ^= ((uint64_t_alias *) temp)[i];
     }
 
     keccakf(st, KECCAK_ROUNDS);


### PR DESCRIPTION
Fix strict-aliasing issue by introducing uint64_t_alias type

Changed all casts from (uint64_t *) to (uint64_t_alias *) to prevent undefined behavior due to strict-aliasing rules.

According to the standard, an object shall only be accessed through an lvalue of a compatible type, or a few exceptions (char types,  or types with similar representation). Accessing a uint64_t object through a different pointer type like void* or another unrelated type is undefined behavior. Introducing uint64_t_alias ensures type-punning without violating these rules.

This ensures safer type-punning while keeping the original logic intact.