### PR TITLE
Fix cryptonight crash when using softaes on arm

### DIFF
--- a/src/crypto/cn/soft_aes.h
+++ b/src/crypto/cn/soft_aes.h
@@ -89,12 +89,33 @@
 alignas(16) const uint32_t saes_table[4][256] = { saes_data(saes_u0), saes_data(saes_u1), saes_data(saes_u2), saes_data(saes_u3) };
 alignas(16) const uint8_t  saes_sbox[256] = saes_data(saes_h0);
 
+typedef union {
+    __m128i m128i;
+    uint32_t u32[4];
+} m128Converter;
+
 static inline __m128i soft_aesenc(const uint32_t* in, __m128i key)
 {
-    const uint32_t x0 = in[0];
-    const uint32_t x1 = in[1];
-    const uint32_t x2 = in[2];
-    const uint32_t x3 = in[3];
+    // working but arm specific
+    // uint32x4_t vector_as_u32 = vreinterpretq_u32_s64(*(int64x2_t*)in);
+    // uint32_t x0 = vgetq_lane_u32(vector_as_u32, 0);
+    // uint32_t x1 = vgetq_lane_u32(vector_as_u32, 1);
+    // uint32_t x2 = vgetq_lane_u32(vector_as_u32, 2);
+    // uint32_t x3 = vgetq_lane_u32(vector_as_u32, 3);
+    
+    // working
+    m128Converter converter;
+    converter.m128i = *(__m128i*)in;
+    const uint32_t x0 = converter.u32[0];
+    const uint32_t x1 = converter.u32[1];
+    const uint32_t x2 = converter.u32[2];
+    const uint32_t x3 = converter.u32[3];
+
+    // these casting may generate wrong results
+    // const uint32_t x0 = in[0];
+    // const uint32_t x1 = in[1];
+    // const uint32_t x2 = in[2];
+    // const uint32_t x3 = in[3];
 
     __m128i out = _mm_set_epi32(
         (saes_table[0][x3 & 0xff] ^ saes_table[1][(x0 >> 8) & 0xff] ^ saes_table[2][(x1 >> 16) & 0xff] ^ saes_table[3][x2 >> 24]),


### PR DESCRIPTION
Cryptonight related algorithms fails to start on arm devices with softaes (e.g. rpi 3, 4). It prints softaes failed. [](https://github.com/MoneroOcean/xmrig/issues/128.) Although the issue is from the MoneroOcean fork, the official version also has this problem. This seems due some unsafe pointer casting in the soft_aesenc function, which causes wrong result on arm platforms using SSE2Neon. Use union to reinterpret __m128i solves the issue.