### PR TITLE
RISC-V: added vectorized soft AES

### DIFF
--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -55,6 +55,18 @@ if (XMRIG_RISCV)
     if(ARCH STREQUAL "native")
         enable_language(ASM)
 
+        try_run(RANDOMX_VECTOR_RUN_FAIL
+            RANDOMX_VECTOR_COMPILE_OK
+            ${CMAKE_CURRENT_BINARY_DIR}/
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/crypto/randomx/tests/riscv64_vector.s
+            COMPILE_DEFINITIONS "-march=rv64gcv_zicbop")
+
+        if (RANDOMX_VECTOR_COMPILE_OK AND NOT RANDOMX_VECTOR_RUN_FAIL)
+            set(RVARCH "${RVARCH}v_zicbop")
+            add_definitions(-DXMRIG_RVV_ENABLED)
+            message(STATUS "RISC-V vector extension detected")
+        endif()
+
         try_run(RANDOMX_ZBA_RUN_FAIL
             RANDOMX_ZBA_COMPILE_OK
             ${CMAKE_CURRENT_BINARY_DIR}/

--- a/src/crypto/randomx/soft_aes.cpp
+++ b/src/crypto/randomx/soft_aes.cpp
@@ -39,6 +39,9 @@ alignas(64) uint32_t lutDec1[256];
 alignas(64) uint32_t lutDec2[256];
 alignas(64) uint32_t lutDec3[256];
 
+alignas(64) uint8_t lutEncIndex[4][32];
+alignas(64) uint8_t lutDecIndex[4][32];
+
 static uint32_t mul_gf2(uint32_t b, uint32_t c)
 {
 	uint32_t s = 0;
@@ -114,6 +117,50 @@ static struct SAESInitializer
 			lutDec1[i] = w; w = (w << 8) | (w >> 24);
 			lutDec2[i] = w; w = (w << 8) | (w >> 24);
 			lutDec3[i] = w;
+		}
+
+		memset(lutEncIndex, -1, sizeof(lutEncIndex));
+		memset(lutDecIndex, -1, sizeof(lutDecIndex));
+
+		lutEncIndex[0][ 0] =  0;
+		lutEncIndex[0][ 4] =  4;
+		lutEncIndex[0][ 8] =  8;
+		lutEncIndex[0][12] = 12;
+		lutEncIndex[1][ 0] =  5;
+		lutEncIndex[1][ 4] =  9;
+		lutEncIndex[1][ 8] = 13;
+		lutEncIndex[1][12] =  1;
+		lutEncIndex[2][ 0] = 10;
+		lutEncIndex[2][ 4] = 14;
+		lutEncIndex[2][ 8] =  2;
+		lutEncIndex[2][12] =  6;
+		lutEncIndex[3][ 0] = 15;
+		lutEncIndex[3][ 4] =  3;
+		lutEncIndex[3][ 8] =  7;
+		lutEncIndex[3][12] = 11;
+
+		lutDecIndex[0][ 0] =  0;
+		lutDecIndex[0][ 4] =  4;
+		lutDecIndex[0][ 8] =  8;
+		lutDecIndex[0][12] = 12;
+		lutDecIndex[1][ 0] = 13;
+		lutDecIndex[1][ 4] =  1;
+		lutDecIndex[1][ 8] =  5;
+		lutDecIndex[1][12] =  9;
+		lutDecIndex[2][ 0] = 10;
+		lutDecIndex[2][ 4] = 14;
+		lutDecIndex[2][ 8] =  2;
+		lutDecIndex[2][12] =  6;
+		lutDecIndex[3][ 0] =  7;
+		lutDecIndex[3][ 4] = 11;
+		lutDecIndex[3][ 8] = 15;
+		lutDecIndex[3][12] =  3;
+
+		for (uint32_t i = 0; i < 4; ++i) {
+			for (uint32_t j = 0; j < 16; j += 4) {
+				lutEncIndex[i][j + 16] = lutEncIndex[i][j] + 16;
+				lutDecIndex[i][j + 16] = lutDecIndex[i][j] + 16;
+			}
 		}
 	}
 } aes_initializer;

--- a/src/crypto/randomx/tests/riscv64_vector.s
+++ b/src/crypto/randomx/tests/riscv64_vector.s
@@ -1,0 +1,14 @@
+/* RISC-V - test if the vector extension and prefetch instruction are present */
+
+.text
+.option arch, rv64gcv_zicbop
+.global main
+
+main:
+	lla x5, main
+	prefetch.r (x5)
+	li x5, 4
+	vsetvli x6, x5, e64, m1, ta, ma
+	vxor.vv v0, v0, v0
+	sub x10, x5, x6
+	ret


### PR DESCRIPTION
Activated when compiling with `-DARCH=native`

Before: 102.5 h/s, after: 107 h/s

Tested on Orange Pi RV2 and got a 2.2x speedup for soft AES itself, but overall speedup was only 4% because it's bottlenecked by memory access.

Note: `--randomx-1gb-pages` is crucial to get max hashrate on Orange Pi RV2

@Slayingripper

<img width="2251" height="1214" alt="Screenshot from 2025-12-05 20-59-51" src="https://github.com/user-attachments/assets/a7a737b6-4508-454b-981f-1fb65c8714a4" />
<img width="2251" height="1214" alt="Screenshot from 2025-12-05 21-05-57" src="https://github.com/user-attachments/assets/74cb37ec-f9d5-4c5f-bc37-10faa5203005" />
