### PR TITLE
fix: cross typos detail below:

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./src/3rdparty,./src/crypto/ghostrider,./src/crypto/randomx/blake2,./src/crypto/cn/sse2neon.h,./src/backend/opencl/cl/cn/groestl256.cl,./src/backend/opencl/cl/cn/jh.cl
+ignore-words-list = Carmel,vor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@
 # v6.16.2
 - [#2751](https://github.com/xmrig/xmrig/pull/2751) Fixed crash on CPUs supporting VAES and running GCC-compiled xmrig.
 - [#2761](https://github.com/xmrig/xmrig/pull/2761) Fixed broken auto-tuning in GCC Windows build.
-- [#2771](https://github.com/xmrig/xmrig/issues/2771) Fixed environment variables support for GhostRider and KawPow. 
+- [#2771](https://github.com/xmrig/xmrig/issues/2771) Fixed environment variables support for GhostRider and KawPow.
 - [#2769](https://github.com/xmrig/xmrig/pull/2769) Performance fixes:
   - Fixed several performance bottlenecks introduced in v6.16.1.
   - Fixed overall GCC-compiled build performance, it's the same speed as MSVC build now.
@@ -468,7 +468,7 @@
 - Compiler for Windows gcc builds updated to v10.1.
 
 # v5.11.1
-- [#1652](https://github.com/xmrig/xmrig/pull/1652) Up to 1% RandomX perfomance improvement on recent AMD CPUs.
+- [#1652](https://github.com/xmrig/xmrig/pull/1652) Up to 1% RandomX performance improvement on recent AMD CPUs.
 - [#1306](https://github.com/xmrig/xmrig/issues/1306) Fixed possible double connection to a pool.
 - [#1654](https://github.com/xmrig/xmrig/issues/1654) Fixed build with LibreSSL.
 
@@ -574,9 +574,9 @@
   - Added automatic huge pages configuration on Linux if use the miner with root privileges.
 - **Added [automatic Intel prefetchers configuration](https://xmrig.com/docs/miner/randomx-optimization-guide#intel-specific-optimizations) on Linux.**
    - Added new option `wrmsr` in `randomx` object with command line equivalent `--randomx-wrmsr=6`.
-- [#1396](https://github.com/xmrig/xmrig/pull/1396) [#1401](https://github.com/xmrig/xmrig/pull/1401) New performance optimizations for Ryzen CPUs. 
-- [#1385](https://github.com/xmrig/xmrig/issues/1385) Added `max-threads-hint` option support for RandomX dataset initialization threads.  
-- [#1386](https://github.com/xmrig/xmrig/issues/1386) Added `priority` option support for RandomX dataset initialization threads. 
+- [#1396](https://github.com/xmrig/xmrig/pull/1396) [#1401](https://github.com/xmrig/xmrig/pull/1401) New performance optimizations for Ryzen CPUs.
+- [#1385](https://github.com/xmrig/xmrig/issues/1385) Added `max-threads-hint` option support for RandomX dataset initialization threads.
+- [#1386](https://github.com/xmrig/xmrig/issues/1386) Added `priority` option support for RandomX dataset initialization threads.
 - For official builds all dependencies (libuv, hwloc, openssl) updated to recent versions.
 - Windows `msvc` builds now use Visual Studio 2019 instead of 2017.
 
@@ -622,7 +622,7 @@ This release based on 4.x.x series and include all features from v4.6.2-beta, ch
 - Removed command line option `--http-enabled`, HTTP API enabled automatically if any other `--http-*` option provided.
 - [#1172](https://github.com/xmrig/xmrig/issues/1172) **Added OpenCL mining backend.**
   - [#268](https://github.com/xmrig/xmrig-amd/pull/268) [#270](https://github.com/xmrig/xmrig-amd/pull/270) [#271](https://github.com/xmrig/xmrig-amd/pull/271) [#273](https://github.com/xmrig/xmrig-amd/pull/273) [#274](https://github.com/xmrig/xmrig-amd/pull/274) [#1171](https://github.com/xmrig/xmrig/pull/1171) Added RandomX support for OpenCL, thanks [@SChernykh](https://github.com/SChernykh).
-- Algorithm `cn/wow` removed, as no longer alive. 
+- Algorithm `cn/wow` removed, as no longer alive.
 
 # Previous versions
 [doc/CHANGELOG_OLD.md](doc/CHANGELOG_OLD.md)

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,8 +1,8 @@
 # HTTP API
 
-If you want use HTTP API you need enable it (`"enabled": true,`) then choice `port` and optionaly `host`. API not available if miner built without HTTP support (`-DWITH_HTTP=OFF`).
+If you want use HTTP API you need enable it (`"enabled": true,`) then choice `port` and optionally `host`. API not available if miner built without HTTP support (`-DWITH_HTTP=OFF`).
 
-Offical HTTP client for API: http://workers.xmrig.info/
+Official HTTP client for API: http://workers.xmrig.info/
 
 Example configuration:
 

--- a/doc/BENCHMARK.md
+++ b/doc/BENCHMARK.md
@@ -17,7 +17,7 @@ Double check that you see `Huge pages 100%` both for dataset and for all threads
 
 ### Benchmark with custom config
 
-You can run benchmark with any configuration you want. Just start without command line parameteres, use regular config.json and add `"benchmark":"1M",` on the next line after pool url. 
+You can run benchmark with any configuration you want. Just start without command line parameters, use regular config.json and add `"benchmark":"1M",` on the next line after pool url.
 
 # Stress test
 

--- a/doc/CHANGELOG_OLD.md
+++ b/doc/CHANGELOG_OLD.md
@@ -57,7 +57,7 @@
 # v4.0.0-beta
 - [#1172](https://github.com/xmrig/xmrig/issues/1172) **Added OpenCL mining backend.**
   - [#268](https://github.com/xmrig/xmrig-amd/pull/268) [#270](https://github.com/xmrig/xmrig-amd/pull/270) [#271](https://github.com/xmrig/xmrig-amd/pull/271) [#273](https://github.com/xmrig/xmrig-amd/pull/273) [#274](https://github.com/xmrig/xmrig-amd/pull/274) [#1171](https://github.com/xmrig/xmrig/pull/1171) Added RandomX support for OpenCL, thanks [@SChernykh](https://github.com/SChernykh).
-- Algorithm `cn/wow` removed, as no longer alive. 
+- Algorithm `cn/wow` removed, as no longer alive.
 
 # v3.2.0
 - Added per pool option `coin` with single possible value `monero` for pools without algorithm negotiation, for upcoming Monero fork.
@@ -103,7 +103,7 @@
 - [#1105](https://github.com/xmrig/xmrig/issues/1105) Improved auto configuration for `cn-pico` algorithm.
 - Added commands `pause` and `resume` via JSON RPC 2.0 API (`POST /json_rpc`).
 - Added command line option `--export-topology` for export hwloc topology to a XML file.
-- Breaked backward compatibility with previous configs and command line, `variant` option replaced to `algo`, global option `algo` removed, all CPU related settings moved to `cpu` object.
+- Broken backward compatibility with previous configs and command line, `variant` option replaced to `algo`, global option `algo` removed, all CPU related settings moved to `cpu` object.
 - Options `av`, `safe` and `max-cpu-usage` removed.
 - Algorithm `cn/msr` renamed to `cn/fast`.
 - Algorithm `cn/xtl` removed.
@@ -122,7 +122,7 @@
 - [#1092](https://github.com/xmrig/xmrig/issues/1092) Fixed crash if wrong CPU affinity used.
 - [#1103](https://github.com/xmrig/xmrig/issues/1103) Improved auto configuration for RandomX for CPUs where L2 cache is limiting factor.
 - [#1105](https://github.com/xmrig/xmrig/issues/1105) Improved auto configuration for `cn-pico` algorithm.
-- [#1106](https://github.com/xmrig/xmrig/issues/1106) Fixed `hugepages` field in summary API. 
+- [#1106](https://github.com/xmrig/xmrig/issues/1106) Fixed `hugepages` field in summary API.
 - Added alternative short format for CPU threads.
 - Changed format for CPU threads with intensity above 1.
 - Name for reference RandomX configuration changed to `rx/test` to avoid potential conflicts in future.
@@ -150,7 +150,7 @@
 - [#1050](https://github.com/xmrig/xmrig/pull/1050) Added RandomXL algorithm for [Loki](https://loki.network/), algorithm name used by miner is `randomx/loki` or `rx/loki`.
 - Added [flexible](https://github.com/xmrig/xmrig/blob/evo/doc/CPU.md) multi algorithm configuration.
 - Added unlimited switching between incompatible algorithms, all mining options can be changed in runtime.
-- Breaked backward compatibility with previous configs and command line, `variant` option replaced to `algo`, global option `algo` removed, all CPU related settings moved to `cpu` object.
+- Broken backward compatibility with previous configs and command line, `variant` option replaced to `algo`, global option `algo` removed, all CPU related settings moved to `cpu` object.
 - Options `av`, `safe` and `max-cpu-usage` removed.
 - Algorithm `cn/msr` renamed to `cn/fast`.
 - Algorithm `cn/xtl` removed.
@@ -183,7 +183,7 @@
 - [#314](https://github.com/xmrig/xmrig-proxy/issues/314) Added donate over proxy feature.
   - Added new option `donate-over-proxy`.
   - Added real graceful exit.
-  
+
 # v2.14.4
 - [#992](https://github.com/xmrig/xmrig/pull/992)  Fixed compilation with Clang 3.5.
 - [#1012](https://github.com/xmrig/xmrig/pull/1012) Fixed compilation with Clang 9.0.
@@ -250,7 +250,7 @@
 # v2.8.1
 - [#768](https://github.com/xmrig/xmrig/issues/768) Fixed build with Visual Studio 2015.
 - [#769](https://github.com/xmrig/xmrig/issues/769) Fixed regression, some ANSI escape sequences was in log with disabled colors.
-- [#777](https://github.com/xmrig/xmrig/issues/777) Better report about pool connection issues. 
+- [#777](https://github.com/xmrig/xmrig/issues/777) Better report about pool connection issues.
 - Simplified checks for ASM auto detection, only AES support necessary.
 - Added missing options to `--help` output.
 
@@ -259,7 +259,7 @@
   - Added global and per thread option `"asm"` and command line equivalent.
 - **[#758](https://github.com/xmrig/xmrig/issues/758) Added SSL/TLS support for secure connections to pools.**
   - Added per pool options `"tls"` and `"tls-fingerprint"` and command line equivalents.
-- [#767](https://github.com/xmrig/xmrig/issues/767) Added config autosave feature, same with GPU miners.  
+- [#767](https://github.com/xmrig/xmrig/issues/767) Added config autosave feature, same with GPU miners.
 - [#245](https://github.com/xmrig/xmrig-proxy/issues/245) Fixed API ID collision when run multiple miners on same machine.
 - [#757](https://github.com/xmrig/xmrig/issues/757) Fixed send buffer overflow.
 
@@ -346,7 +346,7 @@
 
 # v2.4.4
  - Added libmicrohttpd version to --version output.
- - Fixed bug in singal handler, in some cases miner wasn't shutdown properly.
+ - Fixed bug in signal handler, in some cases miner wasn't shutdown properly.
  - Fixed recent MSVC 2017 version detection.
  - [#279](https://github.com/xmrig/xmrig/pull/279) Fixed build on some macOS versions.
 
@@ -359,7 +359,7 @@
 # v2.4.2
  - [#60](https://github.com/xmrig/xmrig/issues/60) Added FreeBSD support, thanks [vcambur](https://github.com/vcambur).
  - [#153](https://github.com/xmrig/xmrig/issues/153) Fixed issues with dwarfpool.com.
- 
+
 # v2.4.1
   - [#147](https://github.com/xmrig/xmrig/issues/147) Fixed comparability with monero-stratum.
 
@@ -371,7 +371,7 @@
  - [#101](https://github.com/xmrig/xmrig/issues/101) Fixed MSVC 2017 (15.3) compile time version detection.
  - [#108](https://github.com/xmrig/xmrig/issues/108) Silently ignore invalid values for `donate-level` option.
  - [#111](https://github.com/xmrig/xmrig/issues/111) Fixed build without AEON support.
- 
+
 # v2.3.1
 - [#68](https://github.com/xmrig/xmrig/issues/68) Fixed compatibility with Docker containers, was nothing print on console.
 
@@ -398,7 +398,7 @@
 # v2.1.0
 - [#40](https://github.com/xmrig/xmrig/issues/40)
 Improved miner shutdown, fixed crash on exit for Linux and OS X.
-- Fixed, login request was contain malformed JSON if username or password has some special characters for example `\`. 
+- Fixed, login request was contain malformed JSON if username or password has some special characters for example `\`.
 - [#220](https://github.com/fireice-uk/xmr-stak-cpu/pull/220) Better support for Round Robin DNS, IP address now always chosen randomly instead of stuck on first one.
 - Changed donation address, new [xmrig-proxy](https://github.com/xmrig/xmrig-proxy) is coming soon.
 
@@ -418,16 +418,16 @@ Improved miner shutdown, fixed crash on exit for Linux and OS X.
  - Fixed Windows XP support.
  - Fixed regression, option `--no-color` was not fully disable colored output.
  - Show resolved pool IP address in miner output.
- 
+
 # v1.0.1
 - Fix broken software AES implementation, app has crashed if CPU not support AES-NI, only version 1.0.0 affected.
 
 # v1.0.0
 - Miner complete rewritten in C++ with libuv.
-- This version should be fully compatible (except config file) with previos versions, many new nice features will come in next versions.
-- This is still beta. If you found regression, stability or perfomance issues or have an idea for new feature please fell free to open new [issue](https://github.com/xmrig/xmrig/issues/new).
+- This version should be fully compatible (except config file) with previous versions, many new nice features will come in next versions.
+- This is still beta. If you found regression, stability or performance issues or have an idea for new feature please fell free to open new [issue](https://github.com/xmrig/xmrig/issues/new).
 - Added new option `--print-time=N`, print hashrate report every N seconds.
-- New hashrate reports, by default every 60 secons.
+- New hashrate reports, by default every 60 seconds.
 - Added Microsoft Visual C++ 2015 and 2017 support.
 - Removed dependency on libcurl.
 - To compile this version from source please switch to [dev](https://github.com/xmrig/xmrig/tree/dev) branch.
@@ -440,7 +440,7 @@ Improved miner shutdown, fixed crash on exit for Linux and OS X.
 - Fixed gcc 7.1 support.
 
 # v0.8.1
-- Added nicehash support, detects automaticaly by pool URL, for example `cryptonight.eu.nicehash.com:3355` or manually via option `--nicehash`.
+- Added nicehash support, detects automatically by pool URL, for example `cryptonight.eu.nicehash.com:3355` or manually via option `--nicehash`.
 
 # v0.8.0
 - Added double hash mode, also known as lower power mode. `--av=2` and `--av=4`.

--- a/doc/CPU.md
+++ b/doc/CPU.md
@@ -124,7 +124,7 @@ Force enable (`true`) or disable (`false`) hardware AES support. Default value `
 Mining threads priority, value from `1` (lowest priority) to `5` (highest possible priority). Default value `null` means miner don't change threads priority at all. Setting priority higher than 2 can make your PC unresponsive.
 
 #### `memory-pool` (since v4.3.0)
-Use continuous, persistent memory block for mining threads, useful for preserve huge pages allocation while algorithm switching. Possible values `false` (feature disabled, by default) or `true` or specific count of 2 MB huge pages. It helps to avoid loosing huge pages for scratchpads when RandomX dataset is updated and mining threads restart after a 2-3 days of mining.
+Use continuous, persistent memory block for mining threads, useful for preserve huge pages allocation while algorithm switching. Possible values `false` (feature disabled, by default) or `true` or specific count of 2 MB huge pages. It helps to avoid losing huge pages for scratchpads when RandomX dataset is updated and mining threads restart after a 2-3 days of mining.
 
 #### `yield` (since v5.1.1)
 Prefer system better system response/stability `true` (default value) or maximum hashrate `false`.
@@ -133,7 +133,7 @@ Prefer system better system response/stability `true` (default value) or maximum
 Enable/configure or disable ASM optimizations. Possible values: `true`, `false`, `"intel"`, `"ryzen"`, `"bulldozer"`.
 
 #### `argon2-impl` (since v3.1.0)
-Allow override automatically detected Argon2 implementation, this option added mostly for debug purposes, default value `null` means autodetect. This is used in RandomX dataset initialization and also in some other mining algorithms. Other possible values: `"x86_64"`, `"SSE2"`, `"SSSE3"`, `"XOP"`, `"AVX2"`, `"AVX-512F"`. Manual selection has no safe guards - if your CPU doesn't support required instuctions, miner will crash.
+Allow override automatically detected Argon2 implementation, this option added mostly for debug purposes, default value `null` means autodetect. This is used in RandomX dataset initialization and also in some other mining algorithms. Other possible values: `"x86_64"`, `"SSE2"`, `"SSSE3"`, `"XOP"`, `"AVX2"`, `"AVX-512F"`. Manual selection has no safe guards - if your CPU doesn't support required instructions, miner will crash.
 
 #### `astrobwt-max-size`
 AstroBWT algorithm: skip hashes with large stage 2 size, default: `550`, min: `400`, max: `1200`. Optimal value depends on your CPU/GPU

--- a/src/backend/opencl/cl/cn/cryptonight.cl
+++ b/src/backend/opencl/cl/cn/cryptonight.cl
@@ -706,7 +706,7 @@ __kernel void cn2(__global uint4 *Scratchpad, __global ulong *states, __global u
     }
 
 #   if (ALGO_FAMILY == FAMILY_CN_HEAVY)
-    /* Also left over threads performe this loop.
+    /* Also left over threads perform this loop.
      * The left over thread results will be ignored
      */
     #pragma unroll 16
@@ -1005,7 +1005,7 @@ __kernel void Groestl(__global ulong *states, __global uint *BranchBuf, __global
         ulong State[8] = { 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0x0001000000000000UL };
         ulong H[8], M[8];
 
-        // BUG: AMD driver 19.7.X crashs if this is written as loop
+        // BUG: AMD driver 19.7.X crashes if this is written as loop
         // Thx AMD for so bad software
         {
             ((ulong8 *)M)[0] = vload8(0, states);

--- a/src/backend/opencl/cl/cn/wolf-skein.cl
+++ b/src/backend/opencl/cl/cn/wolf-skein.cl
@@ -10,7 +10,7 @@
 #else
 #   define STATIC
 /* taken from https://www.khronos.org/registry/OpenCL/extensions/amd/cl_amd_media_ops.txt
- * Build-in Function
+ * Built-in Function
  *     uintn  amd_bitalign (uintn src0, uintn src1, uintn src2)
  *   Description
  *     dst.s0 =  (uint) (((((long)src0.s0) << 32) | (long)src1.s0) >> (src2.s0 & 31))

--- a/src/backend/opencl/cl/kawpow/kawpow.cl
+++ b/src/backend/opencl/cl/kawpow/kawpow.cl
@@ -77,7 +77,7 @@ void keccak_f800_round(uint32_t st[25], const int r)
 void keccak_f800(uint32_t* st)
 {
     // Complete all 22 rounds as a separate impl to
-    // evaluate only first 8 words is wasteful of regsters
+    // evaluate only first 8 words is wasteful of registers
     for (int r = 0; r < 22; r++) {
         keccak_f800_round(st, r);
     }
@@ -181,7 +181,7 @@ __kernel void progpow_search(__global dag_t const* g_dag, __global uint* job_blo
         for (int i = 10; i < 25; i++)
             state[i] = ravencoin_rndc[i-10];
 
-        // Run intial keccak round
+        // Run initial keccak round
         keccak_f800(state);
 
         for (int i = 0; i < 8; i++)

--- a/src/base/crypto/sha3.cpp
+++ b/src/base/crypto/sha3.cpp
@@ -48,7 +48,7 @@
 #define KECCAK_ROUNDS 24
 
 
-/* *************************** Public Inteface ************************ */
+/* *************************** Public Interface ************************ */
 
 /* For Init or Reset call these: */
 sha3_return_t

--- a/src/crypto/cn/c_jh.c
+++ b/src/crypto/cn/c_jh.c
@@ -235,7 +235,7 @@ static HashReturn Init(hashState *state, int hashbitlen)
       /*initialize the initial hash value of JH*/
       state->hashbitlen = hashbitlen;
 
-      /*load the intital hash value into state*/
+      /*load the initial hash value into state*/
       switch (hashbitlen)
       {
             case 224: memcpy(state->x,JH224_H0,128); break;

--- a/src/crypto/cn/skein_port.h
+++ b/src/crypto/cn/skein_port.h
@@ -48,7 +48,7 @@
                                 multiple of size / 8)
 
     ptr_cast(x,size)            casts a pointer to a pointer to a
-                                varaiable of length 'size' bits
+                                variable of length 'size' bits
 */
 
 #define ui_type(size)               uint##size##_t

--- a/src/crypto/randomx/aes_hash.cpp
+++ b/src/crypto/randomx/aes_hash.cpp
@@ -86,7 +86,7 @@ void hashAes1Rx4(const void *input, size_t inputSize, void *hash)
 	rx_vec_i128 state0, state1, state2, state3;
 	rx_vec_i128 in0, in1, in2, in3;
 
-	//intial state
+	//initial state
 	state0 = rx_set_int_vec_i128(AES_HASH_1R_STATE0);
 	state1 = rx_set_int_vec_i128(AES_HASH_1R_STATE1);
 	state2 = rx_set_int_vec_i128(AES_HASH_1R_STATE2);

--- a/src/crypto/randomx/intrin_portable.h
+++ b/src/crypto/randomx/intrin_portable.h
@@ -174,7 +174,7 @@ FORCE_INLINE void rx_set_rounding_mode(uint32_t mode) {
 	_mm_setcsr(rx_mxcsr_default | (mode << 13));
 }
 
-#elif defined(__PPC64__) && defined(__ALTIVEC__) && defined(__VSX__) //sadly only POWER7 and newer will be able to use SIMD acceleration. Earlier processors cant use doubles or 64 bit integers with SIMD
+#elif defined(__PPC64__) && defined(__ALTIVEC__) && defined(__VSX__) //sadly only POWER7 and newer will be able to use SIMD acceleration. Earlier processors can't use doubles or 64 bit integers with SIMD
 #include <cstdint>
 #include <stdexcept>
 #include <cstdlib>

--- a/src/crypto/randomx/randomx.h
+++ b/src/crypto/randomx/randomx.h
@@ -231,7 +231,7 @@ RANDOMX_EXPORT unsigned long randomx_dataset_item_count(void);
  *
  * @param dataset is a pointer to a previously allocated randomx_dataset structure. Must not be NULL.
  * @param cache is a pointer to a previously allocated and initialized randomx_cache structure. Must not be NULL.
- * @param startItem is the item number where intialization should start.
+ * @param startItem is the item number where initialization should start.
  * @param itemCount is the number of items that should be initialized.
 */
 RANDOMX_EXPORT void randomx_init_dataset(randomx_dataset *dataset, randomx_cache *cache, unsigned long startItem, unsigned long itemCount);


### PR DESCRIPTION
What I did
Repository rules / exclusions
I didn’t find repo-specific spelling tooling already in place (no existing codespell config). Given this is a C/C++ repo with vendored sources, I treated src/3rdparty/** as third-party and excluded it from typo fixing (and encoded that in the new .codespellrc). Typos fixed (first-party only)
Docs
CHANGELOG.md: perfomance -> performance
doc/API.md: optionaly -> optionally, Offical -> Official doc/BENCHMARK.md: parameteres -> parameters
doc/CPU.md: loosing -> losing, instuctions -> instructions doc/CHANGELOG_OLD.md: multiple obvious text typos like Breaked -> Broken, singal -> signal, previos -> previous, secons -> seconds, automaticaly -> automatically, perfomance -> performance Code comments / doc comments (safe text-only changes) src/base/crypto/sha3.cpp: Inteface -> Interface (comment banner) src/backend/opencl/cl/cn/cryptonight.cl: performe -> perform, crashs -> crashes (comments) src/backend/opencl/cl/kawpow/kawpow.cl: regsters -> registers, intial -> initial (comments) src/crypto/randomx/aes_hash.cpp: intial -> initial (comment) src/crypto/randomx/intrin_portable.h: cant -> can't (comment) src/crypto/randomx/randomx.h: intialization -> initialization (doc comment) src/crypto/cn/c_jh.c: intital -> initial (comment) src/crypto/cn/skein_port.h: varaiable -> variable (comment) src/backend/opencl/cl/cn/wolf-skein.cl: Build-in -> Built-in (comment) What I intentionally did NOT change
Anything under src/3rdparty/** (vendored).
A few remaining codespell hits are either:
Upstream/embedded sources we excluded (groestl256.cl, jh.cl contain Projet) Potentially valid identifier/name (Carmel CPU codename) Low-risk token in codegen comments (vor inside an instruction comment) These are handled via ignore rules in .codespellrc instead of modifying code.

Added: .codespellrc
Created /.codespellrc with:

skip entries for vendored / embedded upstream areas: ./src/3rdparty
./src/crypto/ghostrider
./src/crypto/randomx/blake2
./src/crypto/cn/sse2neon.h
./src/backend/opencl/cl/cn/groestl256.cl
./src/backend/opencl/cl/cn/jh.cl
ignore-words-list for:
Carmel
vor
Verification
codespell . --config ./.codespellrc now exits clean (exit code 0).