### PR TITLE
RandomX v2: added `commitment` field to stratum submit message

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -363,8 +363,20 @@ void xmrig::CpuWorker<N>::start()
                     }
                     else
 #                   endif
+
                     if (value < job.target()) {
-                        JobResults::submit(job, current_job_nonces[i], m_hash + (i * 32), job.hasMinerSignature() ? miner_signature_saved : nullptr);
+                        uint8_t* extra_data = nullptr;
+
+                        if (job.algorithm().family() == Algorithm::RANDOM_X) {
+                            if (RandomX_CurrentConfig.Tweak_V2_COMMITMENT) {
+                                extra_data = m_commitment;
+                            }
+                            else if (job.hasMinerSignature()) {
+                                extra_data = miner_signature_saved;
+                            }
+                        }
+
+                        JobResults::submit(job, current_job_nonces[i], m_hash + (i * 32), extra_data);
                     }
                 }
                 m_count += N;

--- a/src/crypto/randomx/jit_compiler_x86.cpp
+++ b/src/crypto/randomx/jit_compiler_x86.cpp
@@ -1379,10 +1379,10 @@ namespace randomx {
 
 			if (RandomX_CurrentConfig.Tweak_V2_CFROUND) {
 				if (BranchesWithin32B) {
-					const uint32_t branch_begin = static_cast<uint32_t>(pos + 2) & 31;
+					const uint32_t branch_begin = pos & 31;
 
 					// If the jump crosses or touches 32-byte boundary, align it
-					if (branch_begin >= 30) {
+					if (branch_begin >= 28) {
 						const uint32_t alignment_size = 32 - branch_begin;
 						emit(NOPX[alignment_size - 1], alignment_size, code, pos);
 					}
@@ -1438,10 +1438,10 @@ namespace randomx {
 
 			if (RandomX_CurrentConfig.Tweak_V2_CFROUND) {
 				if (BranchesWithin32B) {
-					const uint32_t branch_begin = static_cast<uint32_t>(pos + 2) & 31;
+					const uint32_t branch_begin = pos & 31;
 
 					// If the jump crosses or touches 32-byte boundary, align it
-					if (branch_begin >= 30) {
+					if (branch_begin >= 28) {
 						const uint32_t alignment_size = 32 - branch_begin;
 						emit(NOPX[alignment_size - 1], alignment_size, code, pos);
 					}

--- a/src/net/JobResults.cpp
+++ b/src/net/JobResults.cpp
@@ -339,9 +339,9 @@ void xmrig::JobResults::submit(const Job &job, uint32_t nonce, const uint8_t *re
 }
 
 
-void xmrig::JobResults::submit(const Job& job, uint32_t nonce, const uint8_t* result, const uint8_t* miner_signature)
+void xmrig::JobResults::submit(const Job& job, uint32_t nonce, const uint8_t* result, const uint8_t* extra_data)
 {
-    submit(JobResult(job, nonce, result, nullptr, nullptr, miner_signature));
+    submit(JobResult(job, nonce, result, nullptr, nullptr, extra_data));
 }
 
 

--- a/src/net/JobResults.h
+++ b/src/net/JobResults.h
@@ -46,7 +46,7 @@ public:
     static void setListener(IJobResultListener *listener, bool hwAES);
     static void stop();
     static void submit(const Job &job, uint32_t nonce, const uint8_t *result);
-    static void submit(const Job& job, uint32_t nonce, const uint8_t* result, const uint8_t* miner_signature);
+    static void submit(const Job& job, uint32_t nonce, const uint8_t* result, const uint8_t* extra_data);
     static void submit(const JobResult &result);
 
 #   if defined(XMRIG_FEATURE_OPENCL) || defined(XMRIG_FEATURE_CUDA)


### PR DESCRIPTION
RandomX commitments were proposed in https://github.com/monero-project/monero/issues/8827, added to RandomX in https://github.com/tevador/RandomX/pull/265 and will go live with the next Monero network upgrade.

`BlockTemplate.h/cpp` and `DaemonClient.h/cpp` were not updated because Monero codebase hasn't implemented commitments yet, so there is no reference code.