### PR TITLE
Fixed GPU validation for `rx/2`.

### DIFF
--- a/src/net/JobResults.cpp
+++ b/src/net/JobResults.cpp
@@ -134,8 +134,22 @@ static void getResults(JobBundle &bundle, std::vector<JobResult> &results, uint3
             *bundle.job.nonce() = nonce;
 
             randomx_calculate_hash(vm, bundle.job.blob(), bundle.job.size(), hash);
+            if (algorithm == Algorithm::RX_V2) {
+                alignas(16) uint8_t rawHash[32]{ 0 };
+                memcpy(rawHash, hash, sizeof(rawHash));
+                randomx_calculate_commitment(bundle.job.blob(), bundle.job.size(), rawHash, hash);
 
-            checkHash(bundle, results, nonce, hash, errors);
+                if (*reinterpret_cast<uint64_t*>(hash + 24) < bundle.job.target()) {
+                    results.emplace_back(bundle.job, nonce, hash, nullptr, nullptr, rawHash);
+                }
+                else {
+                    LOG_ERR("%s " RED_S "GPU #%u COMPUTE ERROR", backend_tag(bundle.job.backend()), bundle.device_index);
+                    ++errors;
+                }
+            }
+            else {
+                checkHash(bundle, results, nonce, hash, errors);
+            }
         }
 
         RxVm::destroy(vm);


### PR DESCRIPTION
  Required for `rx/2` GPU support.

  `JobResults::getResults()` revalidates GPU nonces on CPU before submission. For `rx/2`, the final
  share target must be checked against the commitment, not the raw RandomX hash.

  This patch updates the GPU verification path to:
  - calculate the raw RandomX hash for the returned nonce
  - calculate the `rx/2` commitment from the blob and raw hash
  - validate the commitment against the job target
  - pass the raw hash as extra data so the submit path can send the correct `commitment` field

  No behavior changes for other algorithms.