### PR TITLE
Add rx/mars algorithm: RandomX on Bitcoin-style 80-byte headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,167 @@
+name: Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  linux:
+    name: Linux (x86_64)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git build-essential cmake libuv1-dev libssl-dev libhwloc-dev
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -DWITH_HWLOC=ON -DWITH_OPENCL=OFF -DWITH_CUDA=OFF
+          make -j$(nproc)
+
+      - name: Package
+        run: |
+          cd build
+          tar czf ../xmrig-marscoin-linux-x64.tar.gz xmrig
+          cd ..
+          sha256sum xmrig-marscoin-linux-x64.tar.gz > xmrig-marscoin-linux-x64.tar.gz.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64
+          path: |
+            xmrig-marscoin-linux-x64.tar.gz
+            xmrig-marscoin-linux-x64.tar.gz.sha256
+
+  macos-arm:
+    name: macOS (Apple Silicon)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        run: brew install cmake libuv openssl hwloc
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -DWITH_HWLOC=ON -DWITH_OPENCL=OFF -DWITH_CUDA=OFF -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)
+          make -j$(sysctl -n hw.ncpu)
+
+      - name: Package
+        run: |
+          cd build
+          tar czf ../xmrig-marscoin-macos-arm64.tar.gz xmrig
+          cd ..
+          shasum -a 256 xmrig-marscoin-macos-arm64.tar.gz > xmrig-marscoin-macos-arm64.tar.gz.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64
+          path: |
+            xmrig-marscoin-macos-arm64.tar.gz
+            xmrig-marscoin-macos-arm64.tar.gz.sha256
+
+  macos-intel:
+    name: macOS (Intel)
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        run: brew install cmake libuv openssl hwloc
+
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -DWITH_HWLOC=ON -DWITH_OPENCL=OFF -DWITH_CUDA=OFF -DOPENSSL_ROOT_DIR=$(brew --prefix openssl)
+          make -j$(sysctl -n hw.ncpu)
+
+      - name: Package
+        run: |
+          cd build
+          tar czf ../xmrig-marscoin-macos-x64.tar.gz xmrig
+          cd ..
+          shasum -a 256 xmrig-marscoin-macos-x64.tar.gz > xmrig-marscoin-macos-x64.tar.gz.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-x64
+          path: |
+            xmrig-marscoin-macos-x64.tar.gz
+            xmrig-marscoin-macos-x64.tar.gz.sha256
+
+  windows:
+    name: Windows (x86_64)
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps via vcpkg
+        shell: bash
+        run: |
+          vcpkg install libuv:x64-windows-static openssl:x64-windows-static hwloc:x64-windows-static
+
+      - name: Build
+        shell: bash
+        run: |
+          mkdir build && cd build
+          cmake .. -G "Visual Studio 17 2022" -A x64 \
+            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static \
+            -DWITH_HWLOC=ON -DWITH_OPENCL=OFF -DWITH_CUDA=OFF
+          cmake --build . --config Release -j
+
+      - name: Package
+        shell: bash
+        run: |
+          cd build/Release
+          7z a ../../xmrig-marscoin-windows-x64.zip xmrig.exe
+          cd ../..
+          certutil -hashfile xmrig-marscoin-windows-x64.zip SHA256 > xmrig-marscoin-windows-x64.zip.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64
+          path: |
+            xmrig-marscoin-windows-x64.zip
+            xmrig-marscoin-windows-x64.zip.sha256
+
+  release:
+    name: Publish Release
+    needs: [linux, macos-arm, macos-intel, windows]
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+          generate_release_notes: true
+          body: |
+            Marscoin-patched xmrig with `rx/mars` algorithm for Marscoin's marsqnet testnet.
+
+            ## Usage
+
+            ```
+            ./xmrig -a rx/mars -o stratum+tcp://mining-mars.com:3434 -u YOUR_WORKER_NAME -p x
+            ```
+
+            ## Upstream status
+
+            This fork adds a single RandomX variant for Bitcoin-style 80-byte headers with nonce at offset 76. Upstream PR: https://github.com/xmrig/xmrig/pull/3803
+
+            ## Verification
+
+            Each archive is accompanied by a SHA-256 checksum file.

--- a/src/base/crypto/Algorithm.cpp
+++ b/src/base/crypto/Algorithm.cpp
@@ -83,6 +83,7 @@ const char *Algorithm::kRX_ARQ          = "rx/arq";
 const char *Algorithm::kRX_GRAFT        = "rx/graft";
 const char *Algorithm::kRX_SFX          = "rx/sfx";
 const char *Algorithm::kRX_YADA         = "rx/yada";
+const char *Algorithm::kRX_MARS     = "rx/mars";
 #endif
 
 #ifdef XMRIG_ALGO_ARGON2
@@ -150,6 +151,7 @@ static const std::map<uint32_t, const char *> kAlgorithmNames = {
     ALGO_NAME(RX_GRAFT),
     ALGO_NAME(RX_SFX),
     ALGO_NAME(RX_YADA),
+    ALGO_NAME(RX_MARS),
 #   endif
 
 #   ifdef XMRIG_ALGO_ARGON2
@@ -267,6 +269,8 @@ static const std::map<const char *, Algorithm::Id, aliasCompare> kAlgorithmAlias
                                     ALGO_ALIAS(RX_SFX,          "randomsfx"),
     ALGO_ALIAS_AUTO(RX_YADA),       ALGO_ALIAS(RX_YADA,         "randomx/yada"),
                                     ALGO_ALIAS(RX_YADA,         "randomyada"),
+    ALGO_ALIAS_AUTO(RX_MARS),   ALGO_ALIAS(RX_MARS,     "randomx/mars"),
+                                    ALGO_ALIAS(RX_MARS,     "rx/marscoin"),
 #   endif
 
 #   ifdef XMRIG_ALGO_ARGON2
@@ -354,7 +358,7 @@ std::vector<xmrig::Algorithm> xmrig::Algorithm::all(const std::function<bool(con
         CN_HEAVY_0, CN_HEAVY_TUBE, CN_HEAVY_XHV,
         CN_PICO_0, CN_PICO_TLO,
         CN_UPX2,
-        RX_0, RX_V2, RX_WOW, RX_ARQ, RX_GRAFT, RX_SFX, RX_YADA,
+        RX_0, RX_V2, RX_WOW, RX_ARQ, RX_GRAFT, RX_SFX, RX_YADA, RX_MARS,
         AR2_CHUKWA, AR2_CHUKWA_V2, AR2_WRKZ,
         KAWPOW_RVN,
         GHOSTRIDER_RTM

--- a/src/base/crypto/Algorithm.h
+++ b/src/base/crypto/Algorithm.h
@@ -79,6 +79,7 @@ public:
         RX_GRAFT        = 0x72151267,   // "rx/graft"         RandomGRAFT (Graft).
         RX_SFX          = 0x72151273,   // "rx/sfx"           RandomSFX (Safex Cash).
         RX_YADA         = 0x72151279,   // "rx/yada"          RandomYada (YadaCoin).
+        RX_MARS     = 0x7215126d,   // "rx/mars"      RandomX on Bitcoin-style 80-byte header (Marscoin marsqnet).
         AR2_CHUKWA      = 0x61130000,   // "argon2/chukwa"    Argon2id (Chukwa).
         AR2_CHUKWA_V2   = 0x61140000,   // "argon2/chukwav2"  Argon2id (Chukwa v2).
         AR2_WRKZ        = 0x61120000,   // "argon2/wrkz"      Argon2id (WRKZ)
@@ -146,6 +147,7 @@ public:
     static const char *kRX_GRAFT;
     static const char *kRX_SFX;
     static const char *kRX_YADA;
+    static const char *kRX_MARS;
 #   endif
 
 #   ifdef XMRIG_ALGO_ARGON2

--- a/src/base/net/stratum/Job.cpp
+++ b/src/base/net/stratum/Job.cpp
@@ -169,6 +169,10 @@ size_t xmrig::Job::nonceOffset() const
         return 147;
     }
 
+    if (algorithm() == Algorithm::RX_MARS) {
+        return 76;
+    }
+
     return 39;
 }
 


### PR DESCRIPTION
Marscoin uses a Bitcoin-derived consensus with an 80-byte block header (version + prev_hash + merkle_root + timestamp + bits + nonce) where the nonce sits at offset 76. This differs from CryptoNote-family coins which use variable-length blobs with the nonce at offset 39.

This change adds a new algorithm variant RX_MARS that uses the same reference RandomX configuration as rx/0 but tells Job::nonceOffset() to return 76 instead of 39.

Changes:
- src/base/crypto/Algorithm.h: declare RX_MARS = 0x7215126d + kRX_MARS
- src/base/crypto/Algorithm.cpp: register rx/mars name, aliases (randomx/mars, rx/marscoin), and include in RandomX order list
- src/base/net/stratum/Job.cpp: return 76 from nonceOffset() for RX_MARS

No changes to RandomX core, VM, or OpenCL backends. The RxAlgo default path (RandomX_MoneroConfig) is used.

Usage: ./xmrig -a rx/mars -o stratum+tcp://pool:port -u WORKER -p x