### PR TITLE
Fix build with OpenSSL 4.0.0

### DIFF
--- a/src/base/net/tls/TlsGen.cpp
+++ b/src/base/net/tls/TlsGen.cpp
@@ -115,7 +115,7 @@ bool xmrig::TlsGen::generate_x509(const char *commonName)
     X509_gmtime_adj(X509_get_notAfter(m_x509), 315360000L);
 
     auto name = X509_get_subject_name(m_x509);
-    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const uint8_t *>(commonName), -1, -1, 0);
+    X509_NAME_add_entry_by_txt((X509_NAME *) name, "CN", MBSTRING_ASC, reinterpret_cast<const uint8_t *>(commonName), -1, -1, 0);
 
     X509_set_issuer_name(m_x509, name);
 


### PR DESCRIPTION
```
src/base/net/tls/TlsGen.cpp: In member function 'bool
 xmrig::TlsGen::generate_x509(const char*)':
src/base/net/tls/TlsGen.cpp:118:32: error: invalid conversion from
 'const X509_name_st*' to 'X509_NAME*' {aka 'X509_name_st*'}
 [-fpermissive]
  118 |     X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const uint8_t *>(commonName), -1, -1, 0);
      |                                ^~~~
      |                                |
      |                                const X509_name_st*
```

https://github.com/openssl/openssl/issues/29117