### PR TITLE
Add ARMv9 CPU detection and optimized build flags

### DIFF
--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -178,15 +178,128 @@ if (ARM_TARGET AND ARM_TARGET GREATER 6)
 
     message(STATUS "Use ARM_TARGET=${ARM_TARGET} (${CMAKE_SYSTEM_PROCESSOR})")
 
-    if (ARM_TARGET EQUAL 8 AND (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang))
-        CHECK_CXX_COMPILER_FLAG(-march=armv8-a+crypto XMRIG_ARM_CRYPTO)
+    if (ARM_TARGET EQUAL 8 AND
+        (CMAKE_CXX_COMPILER_ID MATCHES GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang))
+
+        set(XMRIG_ARM_V9 OFF)
+        set(XMRIG_ARM_V9_NAME "")
+
+        if (NOT CMAKE_CROSSCOMPILING)
+            if (APPLE)
+                execute_process(
+                    COMMAND /usr/sbin/sysctl -n machdep.cpu.brand_string
+                    OUTPUT_VARIABLE XMRIG_ARM_BRAND
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET
+                )
+
+                if (XMRIG_ARM_BRAND MATCHES "^Apple M4")
+                    set(XMRIG_ARM_V9 ON)
+                    set(XMRIG_ARM_V9_NAME "Apple M4")
+                endif()
+            elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+                file(GLOB XMRIG_ARM_MIDR_FILES
+                    "/sys/devices/system/cpu/cpu[0-9]*/regs/identification/midr_el1"
+                )
+
+                set(XMRIG_HAS_CORTEX_A520 OFF)
+                set(XMRIG_HAS_CORTEX_A720 OFF)
+
+                foreach(XMRIG_MIDR_FILE IN LISTS XMRIG_ARM_MIDR_FILES)
+                    if (EXISTS "${XMRIG_MIDR_FILE}")
+                        file(READ "${XMRIG_MIDR_FILE}" XMRIG_MIDR)
+                        string(STRIP "${XMRIG_MIDR}" XMRIG_MIDR)
+                        string(TOLOWER "${XMRIG_MIDR}" XMRIG_MIDR)
+
+                        if (XMRIG_MIDR MATCHES "410fd80[0-9a-f]$")
+                            set(XMRIG_HAS_CORTEX_A520 ON)
+                        elseif (XMRIG_MIDR MATCHES "410fd81[0-9a-f]$")
+                            set(XMRIG_HAS_CORTEX_A720 ON)
+                        endif()
+                    endif()
+                endforeach()
+
+                if (XMRIG_HAS_CORTEX_A520 OR XMRIG_HAS_CORTEX_A720)
+                    set(XMRIG_ARM_V9 ON)
+
+                    if (XMRIG_HAS_CORTEX_A520 AND XMRIG_HAS_CORTEX_A720)
+                        set(XMRIG_ARM_V9_NAME "Cortex-A520/A720")
+                    elseif (XMRIG_HAS_CORTEX_A520)
+                        set(XMRIG_ARM_V9_NAME "Cortex-A520")
+                    else()
+                        set(XMRIG_ARM_V9_NAME "Cortex-A720")
+                    endif()
+                endif()
+            endif()
+        endif()
+
+        if (XMRIG_ARM_V9)
+            CHECK_CXX_COMPILER_FLAG("-mcpu=native" XMRIG_ARM_NATIVE_SUPPORTED)
+
+            if (XMRIG_ARM_NATIVE_SUPPORTED)
+                if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+                    XMRIG_HAS_CORTEX_A520 AND
+                    XMRIG_HAS_CORTEX_A720)
+                    set(ARM8_CXX_FLAGS
+                        "-march=armv9.2-a+crypto+sha3 -mtune=cortex-a720"
+                    )
+                else()
+                    set(ARM8_CXX_FLAGS "-mcpu=native")
+                endif()
+
+                add_definitions(-DXMRIG_ARM_V9)
+
+                message(STATUS
+                    "Detected ARMv9 CPU: ${XMRIG_ARM_V9_NAME}, using ${ARM8_CXX_FLAGS}"
+                )
+            else()
+                message(WARNING
+                    "Detected ARMv9 CPU, but compiler does not support -mcpu=native"
+                )
+            endif()
+        endif()
+
+        if (NOT ARM8_CXX_FLAGS)
+            CHECK_CXX_COMPILER_FLAG(
+                "-march=armv8-a+crypto"
+                XMRIG_ARM_CRYPTO_FLAG
+            )
+
+            if (XMRIG_ARM_CRYPTO_FLAG)
+                set(ARM8_CXX_FLAGS "-march=armv8-a+crypto")
+            else()
+                set(ARM8_CXX_FLAGS "-march=armv8-a")
+            endif()
+        endif()
+
+        set(CMAKE_REQUIRED_FLAGS_SAVE "${CMAKE_REQUIRED_FLAGS}")
+        set(CMAKE_REQUIRED_FLAGS
+            "${CMAKE_REQUIRED_FLAGS} ${ARM8_CXX_FLAGS}"
+        )
+
+        include(CheckCXXSourceCompiles)
+
+        check_cxx_source_compiles("
+            #include <arm_neon.h>
+
+            int main()
+            {
+                uint8x16_t a = vdupq_n_u8(0);
+                uint8x16_t b = vdupq_n_u8(0);
+                a = vaeseq_u8(a, b);
+
+                return vgetq_lane_u8(a, 0);
+            }
+        " XMRIG_ARM_CRYPTO)
+
+        set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE}")
+        unset(CMAKE_REQUIRED_FLAGS_SAVE)
 
         if (XMRIG_ARM_CRYPTO)
             add_definitions(-DXMRIG_ARM_CRYPTO)
-            set(ARM8_CXX_FLAGS "-march=armv8-a+crypto")
-        else()
-            set(ARM8_CXX_FLAGS "-march=armv8-a")
         endif()
+
+        message(STATUS "ARM compiler flags: ${ARM8_CXX_FLAGS}")
     endif()
 endif()
 

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -241,7 +241,7 @@ if (ARM_TARGET AND ARM_TARGET GREATER 6)
                     XMRIG_HAS_CORTEX_A520 AND
                     XMRIG_HAS_CORTEX_A720)
                     set(ARM8_CXX_FLAGS
-                        "-march=armv9.2-a+crypto+sha3 -mtune=cortex-a720"
+                        "-march=armv9.2-a+crypto -mtune=cortex-a720"
                     )
                 else()
                     set(ARM8_CXX_FLAGS "-mcpu=native")

--- a/src/backend/cpu/platform/BasicCpuInfo_arm.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm.cpp
@@ -34,7 +34,7 @@ xmrig::BasicCpuInfo::BasicCpuInfo() :
     }
 
 #   if (XMRIG_ARM == 8)
-    memcpy(m_brand, "ARMv8", 5);
+    memcpy(m_brand, "AArch64", 7);
 #   else
     memcpy(m_brand, "ARMv7", 5);
 #   endif

--- a/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
@@ -6,6 +6,14 @@
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "backend/cpu/platform/BasicCpuInfo.h"

--- a/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
@@ -42,7 +42,8 @@ void xmrig::BasicCpuInfo::init_arm()
 
     m_brand[sizeof(m_brand) - 1] = '\0';
 
-    if (std::strncmp(m_brand, "Apple M4", 8) == 0) {
+    if (std::strncmp(m_brand, "Apple M4", 8) == 0 ||
+        std::strncmp(m_brand, "Apple M5", 8) == 0) {
         constexpr const char suffix[] = " (ARMv9)";
         const size_t used = std::strlen(m_brand);
 

--- a/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm_mac.cpp
@@ -6,27 +6,40 @@
  *   it under the terms of the GNU General Public License as published by
  *   the Free Software Foundation, either version 3 of the License, or
  *   (at your option) any later version.
- *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *   GNU General Public License for more details.
- *
- *   You should have received a copy of the GNU General Public License
- *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "backend/cpu/platform/BasicCpuInfo.h"
 
+#include <cstdio>
+#include <cstring>
 #include <sys/sysctl.h>
 
 
 void xmrig::BasicCpuInfo::init_arm()
 {
-#   if __ARM_FEATURE_CRYPTO
-    m_flags.set(FLAG_AES, true); // FIXME
-#   endif
+    int aes = 0;
+    size_t aesSize = sizeof(aes);
+
+    if (sysctlbyname("hw.optional.arm.FEAT_AES",
+                     &aes, &aesSize, nullptr, 0) == 0 && aes == 1) {
+        m_flags.set(FLAG_AES, true);
+    }
 
     size_t buflen = sizeof(m_brand);
-    sysctlbyname("machdep.cpu.brand_string", &m_brand, &buflen, nullptr, 0);
+
+    if (sysctlbyname("machdep.cpu.brand_string",
+                     m_brand, &buflen, nullptr, 0) != 0) {
+        std::snprintf(m_brand, sizeof(m_brand), "Apple ARM");
+    }
+
+    m_brand[sizeof(m_brand) - 1] = '\0';
+
+    if (std::strncmp(m_brand, "Apple M4", 8) == 0) {
+        constexpr const char suffix[] = " (ARMv9)";
+        const size_t used = std::strlen(m_brand);
+
+        if (used + sizeof(suffix) <= sizeof(m_brand)) {
+            std::memcpy(m_brand + used, suffix, sizeof(suffix));
+        }
+    }
 }

--- a/src/backend/cpu/platform/BasicCpuInfo_arm_unix.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_arm_unix.cpp
@@ -20,7 +20,11 @@
 #include "base/tools/String.h"
 
 
+#include <cstdio>
+#include <cstring>
 #include <fstream>
+#include <string>
+#include <thread>
 
 
 #if __ARM_FEATURE_CRYPTO
@@ -43,6 +47,88 @@ namespace xmrig {
 extern String cpu_name_arm();
 
 
+static void appendArmVersion(char *brand, size_t size)
+{
+#   if defined(XMRIG_OS_LINUX)
+    bool hasA520 = false;
+    bool hasA720 = false;
+
+    for (unsigned int cpu = 0; cpu < 1024; ++cpu) {
+        char path[160];
+
+        std::snprintf(
+            path,
+            sizeof(path),
+            "/sys/devices/system/cpu/cpu%u/regs/identification/midr_el1",
+            cpu
+        );
+
+        std::ifstream file(path);
+
+        if (!file.good()) {
+            if (cpu >= std::thread::hardware_concurrency()) {
+                break;
+            }
+
+            continue;
+        }
+
+        std::string value;
+        file >> value;
+
+        if (value.empty()) {
+            continue;
+        }
+
+        unsigned long long midr = 0;
+
+        try {
+            midr = std::stoull(value, nullptr, 0);
+        }
+        catch (...) {
+            continue;
+        }
+
+        const unsigned int implementer =
+            static_cast<unsigned int>((midr >> 24) & 0xff);
+
+        const unsigned int part =
+            static_cast<unsigned int>((midr >> 4) & 0xfff);
+
+        if (implementer != 0x41) {
+            continue;
+        }
+
+        if (part == 0xd80) {
+            hasA520 = true;
+        }
+        else if (part == 0xd81) {
+            hasA720 = true;
+        }
+    }
+
+    const char *suffix = nullptr;
+
+    if (hasA520 && hasA720) {
+        suffix = " Cortex-A520/A720 (ARMv9.2-A)";
+    }
+    else if (hasA520) {
+        suffix = " Cortex-A520 (ARMv9.2-A)";
+    }
+    else if (hasA720) {
+        suffix = " Cortex-A720 (ARMv9.2-A)";
+    }
+
+    if (suffix != nullptr) {
+        std::snprintf(brand, size, "ARM%s", suffix);
+    }
+#   else
+    (void) brand;
+    (void) size;
+#   endif
+}
+
+
 } // namespace xmrig
 
 
@@ -51,7 +137,10 @@ void xmrig::BasicCpuInfo::init_arm()
 #   if __ARM_FEATURE_CRYPTO
 #   if defined(XMRIG_OS_FREEBSD)
     uint64_t isar0 = READ_SPECIALREG(id_aa64isar0_el1);
-    m_flags.set(FLAG_AES, ID_AA64ISAR0_AES_VAL(isar0) >= ID_AA64ISAR0_AES_BASE);
+    m_flags.set(
+        FLAG_AES,
+        ID_AA64ISAR0_AES_VAL(isar0) >= ID_AA64ISAR0_AES_BASE
+    );
 #   else
     m_flags.set(FLAG_AES, getauxval(AT_HWCAP) & HWCAP_AES);
 #   endif
@@ -59,10 +148,19 @@ void xmrig::BasicCpuInfo::init_arm()
 
 #   if defined(XMRIG_OS_UNIX)
     auto name = cpu_name_arm();
+
     if (!name.isNull()) {
-        strncpy(m_brand, name, sizeof(m_brand) - 1);
+        std::strncpy(m_brand, name, sizeof(m_brand) - 1);
+        m_brand[sizeof(m_brand) - 1] = '\0';
     }
 
-    m_flags.set(FLAG_PDPE1GB, std::ifstream("/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages").good());
+    appendArmVersion(m_brand, sizeof(m_brand));
+
+    m_flags.set(
+        FLAG_PDPE1GB,
+        std::ifstream(
+            "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages"
+        ).good()
+    );
 #   endif
 }

--- a/src/base/kernel/config/BaseConfig.cpp
+++ b/src/base/kernel/config/BaseConfig.cpp
@@ -142,7 +142,13 @@ void xmrig::BaseConfig::printVersions()
     snprintf(buf, sizeof buf, "MSVC/%d", MSVC_VERSION);
 #   endif
 
-    Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s") CYAN_BOLD("%s/%s") WHITE_BOLD(" %s") WHITE_BOLD(" (built for %s") WHITE_BOLD(" %s,") WHITE_BOLD(" %s)"), "ABOUT", APP_NAME, APP_VERSION, buf, APP_OS, APP_ARCH, APP_BITS);
+    const char *appArch = APP_ARCH;
+
+#   if defined(XMRIG_ARM_V9)
+    appArch = "ARMv9";
+#   endif
+
+    Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s") CYAN_BOLD("%s/%s") WHITE_BOLD(" %s") WHITE_BOLD(" (built for %s") WHITE_BOLD(" %s,") WHITE_BOLD(" %s)"), "ABOUT", APP_NAME, APP_VERSION, buf, APP_OS, appArch, APP_BITS);
 
     std::string libs;
 


### PR DESCRIPTION
This PR adds ARMv9 CPU detection and architecture-specific build flags for modern ARM processors.

Changes:
- Detect Apple M4 on macOS and report it as ARMv9.
- Detect Cortex-A520 and Cortex-A720 through MIDR on Linux.
- Report ARMv9 in the XMRig build banner when appropriate.
- Use `-mcpu=native` on Apple Silicon.
- Use `-march=armv9.2-a+crypto+sha3 -mtune=cortex-a720` on Cortex-A520/A720 systems.
- Preserve the existing ARMv8 fallback for older ARM64 processors.
- Verify AES intrinsics using a compile test.

Tested on:
- Apple M4, macOS, AppleClang 21
- Orange Pi 6 Plus, Cortex-A520/A720, GCC 14.3
- Orange Pi 5, Cortex-A55 ARMv8, GCC 14.3

Observed runtime detection:
- `Apple M4 (ARMv9)`
- `ARM Cortex-A520/A720 (ARMv9.2-A)`
- ARMv8 fallback remains functional on Cortex-A55