### PR TITLE
RISC-V: detect VLEN at runtime and speed up the RVV paths

### DIFF
--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -42,6 +42,11 @@
 #endif
 
 
+#ifdef XMRIG_RISCV
+#   include "backend/cpu/platform/riscv_vlen.h"
+#endif
+
+
 namespace xmrig {
 
 
@@ -89,13 +94,28 @@ static void print_cpu(const Config *)
 {
     const auto info = Cpu::info();
 
+#   ifdef XMRIG_RISCV
+    // VLEN is per-hart on RISC-V, so report what the main thread actually sees.
+    char rvv[64] = {};
+    const uint32_t vlen = riscv_vlen();
+    if (vlen >= RISCV_MIN_VLEN) {
+        snprintf(rvv, sizeof(rvv), GREEN_BOLD_S "RVV%u ", vlen);
+    }
+    else if (vlen) {
+        snprintf(rvv, sizeof(rvv), RED_BOLD_S "-RVV%u(too narrow) ", vlen);
+    }
+    else {
+        snprintf(rvv, sizeof(rvv), RED_BOLD_S "-RVV ");
+    }
+#   endif
+
     Log::print(GREEN_BOLD(" * ") WHITE_BOLD("%-13s%s (%zu)") " %s %s%sAES%s",
                "CPU",
                info->brand(),
                info->packages(),
                ICpuInfo::is64bit()    ? GREEN_BOLD("64-bit") : RED_BOLD("32-bit"),
 #ifdef XMRIG_RISCV
-               info->hasRISCV_Vector() ? GREEN_BOLD_S "RVV " : RED_BOLD_S "-RVV ",
+               rvv,
 #else
                "",
 #endif

--- a/src/backend/cpu/cpu.cmake
+++ b/src/backend/cpu/cpu.cmake
@@ -47,6 +47,7 @@ else()
 endif()
 
 if (XMRIG_RISCV)
+    list(APPEND HEADERS_BACKEND_CPU src/backend/cpu/platform/riscv_vlen.h)
     list(APPEND SOURCES_BACKEND_CPU
         src/backend/cpu/platform/lscpu_riscv.cpp
         src/backend/cpu/platform/BasicCpuInfo_riscv.cpp

--- a/src/backend/cpu/platform/BasicCpuInfo_riscv.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo_riscv.cpp
@@ -25,6 +25,7 @@
 
 
 #include "backend/cpu/platform/BasicCpuInfo.h"
+#include "backend/cpu/platform/riscv_vlen.h"
 #include "base/tools/String.h"
 #include "3rdparty/rapidjson/document.h"
 
@@ -106,11 +107,16 @@ rapidjson::Value xmrig::BasicCpuInfo::toJSON(rapidjson::Document &doc) const
     out.AddMember("msr",        "none", allocator);
     out.AddMember("assembly",   "none", allocator);
     out.AddMember("arch",       "riscv64", allocator);
+    out.AddMember("vlen",       static_cast<uint64_t>(riscv_vlen()), allocator);
 
     Value flags(kArrayType);
 
     if (hasAES()) {
         flags.PushBack("aes", allocator);
+    }
+
+    if (riscv_vlen() >= RISCV_MIN_VLEN) {
+        flags.PushBack("rvv", allocator);
     }
 
     out.AddMember("flags", flags, allocator);

--- a/src/backend/cpu/platform/lscpu_riscv.cpp
+++ b/src/backend/cpu/platform/lscpu_riscv.cpp
@@ -17,9 +17,11 @@
  *   along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "backend/cpu/platform/riscv_vlen.h"
 #include "base/tools/String.h"
 #include "3rdparty/fmt/core.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -145,6 +147,39 @@ bool has_riscv_aes()
         return desc.has_aes;
     }
     return false;
+}
+
+
+// Reads the vlenb CSR. Only valid once the V extension is known to be present,
+// otherwise it traps. The .option block keeps this assembling even when the
+// translation unit is built without "v" in -march.
+static inline uint32_t read_vlenb()
+{
+    unsigned long vlenb;
+
+    __asm__ volatile(
+        ".option push\n\t"
+        ".option arch, +v\n\t"
+        "vsetvli t0, x0, e8, m1, ta, ma\n\t"
+        "csrr %0, vlenb\n\t"
+        ".option pop"
+        : "=r"(vlenb)
+        :
+        : "t0");
+
+    return static_cast<uint32_t>(vlenb);
+}
+
+
+uint32_t riscv_vlen()
+{
+    static thread_local uint32_t vlen = UINT32_MAX;
+
+    if (vlen == UINT32_MAX) {
+        vlen = has_riscv_vector() ? read_vlenb() * 8 : 0;
+    }
+
+    return vlen;
 }
 
 } // namespace xmrig

--- a/src/backend/cpu/platform/riscv_vlen.h
+++ b/src/backend/cpu/platform/riscv_vlen.h
@@ -1,0 +1,52 @@
+/* XMRig
+ * Copyright (c) 2016-2025 XMRig         <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef XMRIG_RISCV_VLEN_H
+#define XMRIG_RISCV_VLEN_H
+
+
+#include <cstdint>
+
+
+namespace xmrig {
+
+
+/*
+ * Vector register length (VLEN) in bits for the *calling thread*, or 0 when the
+ * V extension is not available.
+ *
+ * The RVV kernels use a fixed application vector length (AVL) with LMUL=1, so
+ * they need VLMAX to be at least that big. When VLEN is too small the hardware
+ * silently clamps vl and the kernels compute wrong results instead of faulting,
+ * which is why every RVV dispatch has to consult this.
+ *
+ * VLEN is a per-hart property and RISC-V does not require it to be uniform
+ * across a system: the SpacemiT K3 pairs 256-bit X100 cores with 1024-bit A100
+ * cores, and a thread's VLEN depends on which cluster it is pinned to. The
+ * value is therefore cached per thread, not globally.
+ */
+uint32_t riscv_vlen();
+
+
+// Smallest VLEN the RVV code paths can run on.
+constexpr uint32_t RISCV_MIN_VLEN = 256;
+
+
+} // namespace xmrig
+
+
+#endif /* XMRIG_RISCV_VLEN_H */

--- a/src/crypto/randomx/aes_hash.cpp
+++ b/src/crypto/randomx/aes_hash.cpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "backend/cpu/Cpu.h"
 
 #ifdef XMRIG_RISCV
+#include "backend/cpu/platform/riscv_vlen.h"
 #include "crypto/randomx/aes_hash_rv64_vector.hpp"
 #include "crypto/randomx/aes_hash_rv64_zvkned.hpp"
 #endif
@@ -69,13 +70,16 @@ template<int softAes>
 void hashAes1Rx4(const void *input, size_t inputSize, void *hash)
 {
 #ifdef XMRIG_RISCV
-	if (xmrig::Cpu::info()->hasAES()) {
-		hashAes1Rx4_zvkned(input, inputSize, hash);
-		return;
-	}
-
-	if (xmrig::Cpu::info()->hasRISCV_Vector()) {
-		hashAes1Rx4_RVV(input, inputSize, hash);
+	// Both kernels use a fixed AVL of 8 32-bit elements at LMUL=1, so they need
+	// VLMAX >= 8, i.e. VLEN >= 256. Smaller vector units silently clamp vl and
+	// would corrupt the hash rather than fault.
+	if (xmrig::riscv_vlen() >= xmrig::RISCV_MIN_VLEN) {
+		if (xmrig::Cpu::info()->hasAES()) {
+			hashAes1Rx4_zvkned(input, inputSize, hash);
+		}
+		else {
+			hashAes1Rx4_RVV(input, inputSize, hash);
+		}
 		return;
 	}
 #endif
@@ -150,13 +154,13 @@ template<int softAes>
 void fillAes1Rx4(void *state, size_t outputSize, void *buffer)
 {
 #ifdef XMRIG_RISCV
-	if (xmrig::Cpu::info()->hasAES()) {
-		fillAes1Rx4_zvkned(state, outputSize, buffer);
-		return;
-	}
-
-	if (xmrig::Cpu::info()->hasRISCV_Vector()) {
-		fillAes1Rx4_RVV(state, outputSize, buffer);
+	if (xmrig::riscv_vlen() >= xmrig::RISCV_MIN_VLEN) {
+		if (xmrig::Cpu::info()->hasAES()) {
+			fillAes1Rx4_zvkned(state, outputSize, buffer);
+		}
+		else {
+			fillAes1Rx4_RVV(state, outputSize, buffer);
+		}
 		return;
 	}
 #endif
@@ -207,13 +211,13 @@ template<int softAes>
 void fillAes4Rx4(void *state, size_t outputSize, void *buffer)
 {
 #ifdef XMRIG_RISCV
-	if (xmrig::Cpu::info()->hasAES()) {
-		fillAes4Rx4_zvkned(state, outputSize, buffer);
-		return;
-	}
-
-	if (xmrig::Cpu::info()->hasRISCV_Vector()) {
-		fillAes4Rx4_RVV(state, outputSize, buffer);
+	if (xmrig::riscv_vlen() >= xmrig::RISCV_MIN_VLEN) {
+		if (xmrig::Cpu::info()->hasAES()) {
+			fillAes4Rx4_zvkned(state, outputSize, buffer);
+		}
+		else {
+			fillAes4Rx4_RVV(state, outputSize, buffer);
+		}
 		return;
 	}
 #endif
@@ -291,13 +295,13 @@ void hashAndFillAes1Rx4(void *scratchpad, size_t scratchpadSize, void *hash, voi
 	PROFILE_SCOPE(RandomX_AES);
 
 #ifdef XMRIG_RISCV
-	if (xmrig::Cpu::info()->hasAES()) {
-		hashAndFillAes1Rx4_zvkned(scratchpad, scratchpadSize, hash, fill_state);
-		return;
-	}
-
-	if (xmrig::Cpu::info()->hasRISCV_Vector()) {
-		hashAndFillAes1Rx4_RVV(scratchpad, scratchpadSize, hash, fill_state);
+	if (xmrig::riscv_vlen() >= xmrig::RISCV_MIN_VLEN) {
+		if (xmrig::Cpu::info()->hasAES()) {
+			hashAndFillAes1Rx4_zvkned(scratchpad, scratchpadSize, hash, fill_state);
+		}
+		else {
+			hashAndFillAes1Rx4_RVV(scratchpad, scratchpadSize, hash, fill_state);
+		}
 		return;
 	}
 #endif

--- a/src/crypto/randomx/aes_hash_rv64_vector.cpp
+++ b/src/crypto/randomx/aes_hash_rv64_vector.cpp
@@ -69,6 +69,26 @@ static constexpr uint32_t AES_HASH_1R_XKEY11[8] = { 0x61b263d1, 0x51f4e03c, 0xee
 static constexpr uint32_t AES_HASH_STRIDE_X2[8] = { 0, 4, 8, 12, 32, 36, 40, 44 };
 static constexpr uint32_t AES_HASH_STRIDE_X4[8] = { 0, 4, 8, 12, 64, 68, 72, 76 };
 
+/*
+	The four 16-byte AES lanes sit consecutively in memory, but the kernels need
+	them grouped as {0,2} and {1,3}. An indexed access does that in one
+	instruction, but indexed accesses are an order of magnitude slower than
+	unit-stride ones on both SpacemiT cores, so pick the halves up separately and
+	glue them together with a slide instead.
+*/
+static FORCE_INLINE vuint32m1_t load_lane_pair(const uint8_t* p, size_t lo, size_t hi)
+{
+	return __riscv_vslideup_vx_u32m1(
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + lo), 4),
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + hi), 4), 4, 8);
+}
+
+static FORCE_INLINE void store_lane_pair(uint8_t* p, size_t lo, size_t hi, vuint32m1_t v)
+{
+	__riscv_vse32_v_u32m1((uint32_t*)(p + lo), v, 4);
+	__riscv_vse32_v_u32m1((uint32_t*)(p + hi), __riscv_vslidedown_vx_u32m1(v, 4, 4), 4);
+}
+
 #define lutEnc0 lutEnc[0]
 #define lutEnc1 lutEnc[1]
 #define lutEnc2 lutEnc[2]
@@ -101,8 +121,8 @@ void hashAes1Rx4_RVV(const void *input, size_t inputSize, void *hash) {
 
 	//process 64 bytes at a time in 4 lanes
 	while (inptr < inputEnd) {
-		state02 = softaes_vector_double(state02, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 0, stride, 8), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
-		state13 = softaes_vector_double(state13, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 4, stride, 8), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
+		state02 = softaes_vector_double(state02, load_lane_pair(inptr,  0, 32), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
+		state13 = softaes_vector_double(state13, load_lane_pair(inptr, 16, 48), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 
 		inptr += 64;
 	}
@@ -123,7 +143,7 @@ void hashAes1Rx4_RVV(const void *input, size_t inputSize, void *hash) {
 }
 
 void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t key02 = __riscv_vle32_v_u32m1(AES_GEN_1R_KEY02, 8);
@@ -148,8 +168,8 @@ void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 		state02 = softaes_vector_double(state02, key02, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 		state13 = softaes_vector_double(state13, key13, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -159,7 +179,7 @@ void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 }
 
 void fillAes4Rx4_RVV(void *state, size_t outputSize, void *buffer) {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t stride4 = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X4, 8);
@@ -197,8 +217,8 @@ void fillAes4Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 		state02 = softaes_vector_double(state02, key37, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 		state13 = softaes_vector_double(state13, key37, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -232,14 +252,14 @@ void hashAndFillAes1Rx4_RVV(void *scratchpad, size_t scratchpadSize, void *hash,
 	//process 64 bytes at a time in 4 lanes
 	while (scratchpadPtr < scratchpadEnd) {
 #define HASH_STATE(k) \
-		hash_state02 = softaes_vector_double(hash_state02, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 0, stride, 8), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
-		hash_state13 = softaes_vector_double(hash_state13, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 4, stride, 8), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
+		hash_state02 = softaes_vector_double(hash_state02, load_lane_pair(scratchpadPtr + k * 64,  0, 32), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
+		hash_state13 = softaes_vector_double(hash_state13, load_lane_pair(scratchpadPtr + k * 64, 16, 48), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 
 #define FILL_STATE(k) \
 		fill_state02 = softaes_vector_double(fill_state02, key02, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3); \
 		fill_state13 = softaes_vector_double(fill_state13, key13, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 0, stride, fill_state02, 8); \
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 4, stride, fill_state13, 8);
+		store_lane_pair(scratchpadPtr + k * 64,  0, 32, fill_state02); \
+		store_lane_pair(scratchpadPtr + k * 64, 16, 48, fill_state13);
 
 		HASH_STATE(0);
 		HASH_STATE(1);

--- a/src/crypto/randomx/aes_hash_rv64_zvkned.cpp
+++ b/src/crypto/randomx/aes_hash_rv64_zvkned.cpp
@@ -36,6 +36,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static FORCE_INLINE vuint32m1_t aesenc_zvkned(vuint32m1_t a, vuint32m1_t b) { return __riscv_vaesem_vv_u32m1(a, b, 8); }
 static FORCE_INLINE vuint32m1_t aesdec_zvkned(vuint32m1_t a, vuint32m1_t b, vuint32m1_t zero) { return __riscv_vxor_vv_u32m1(__riscv_vaesdm_vv_u32m1(a, zero, 8), b, 8); }
 
+/*
+	The four 16-byte AES lanes sit consecutively in memory, but the kernels need
+	them grouped as {0,2} and {1,3} because those pairs share an AES direction.
+	An indexed access does the regrouping in a single instruction, which is what
+	the strided AES_HASH_STRIDE_X2 index vector is for - but indexed accesses are
+	an order of magnitude slower than unit-stride ones on both SpacemiT cores
+	(gather ~16x a vle32 on X100, ~14x on A100; scatter ~8x and ~36x), so it pays
+	to pick the two halves up separately and glue them together with a slide.
+*/
+static FORCE_INLINE vuint32m1_t load_lane_pair(const uint8_t* p, size_t lo, size_t hi)
+{
+	return __riscv_vslideup_vx_u32m1(
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + lo), 4),
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + hi), 4), 4, 8);
+}
+
+static FORCE_INLINE void store_lane_pair(uint8_t* p, size_t lo, size_t hi, vuint32m1_t v)
+{
+	__riscv_vse32_v_u32m1((uint32_t*)(p + lo), v, 4);
+	__riscv_vse32_v_u32m1((uint32_t*)(p + hi), __riscv_vslidedown_vx_u32m1(v, 4, 4), 4);
+}
+
 static constexpr uint32_t AES_HASH_1R_STATE02[8] = { 0x92b52c0d, 0x9fa856de, 0xcc82db47, 0xd7983aad, 0x6a770017, 0xae62c7d0, 0x5079506b, 0xe8a07ce4 };
 static constexpr uint32_t AES_HASH_1R_STATE13[8] = { 0x338d996e, 0x15c7b798, 0xf59e125a, 0xace78057, 0x630a240c, 0x07ad828d, 0x79a10005, 0x7e994948 };
 
@@ -62,8 +84,8 @@ void hashAes1Rx4_zvkned(const void *input, size_t inputSize, void *hash)
 
 	//process 64 bytes at a time in 4 lanes
 	while (inptr < inputEnd) {
-		state02 = aesenc_zvkned(state02, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 0, stride, 8));
-		state13 = aesdec_zvkned(state13, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 4, stride, 8), zero);
+		state02 = aesenc_zvkned(state02, load_lane_pair(inptr,  0, 32));
+		state13 = aesdec_zvkned(state13, load_lane_pair(inptr, 16, 48), zero);
 
 		inptr += 64;
 	}
@@ -85,7 +107,7 @@ void hashAes1Rx4_zvkned(const void *input, size_t inputSize, void *hash)
 
 void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t key02 = __riscv_vle32_v_u32m1(AES_GEN_1R_KEY02, 8);
@@ -101,8 +123,8 @@ void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 		state02 = aesdec_zvkned(state02, key02, zero);
 		state13 = aesenc_zvkned(state13, key13);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -113,7 +135,7 @@ void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 
 void fillAes4Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t stride4 = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X4, 8);
@@ -142,8 +164,8 @@ void fillAes4Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 		state02 = aesdec_zvkned(state02, key37, zero);
 		state13 = aesenc_zvkned(state13, key37);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -168,14 +190,16 @@ void hashAndFillAes1Rx4_zvkned(void *scratchpad, size_t scratchpadSize, void *ha
 
 	//process 64 bytes at a time in 4 lanes
 	while (scratchpadPtr < scratchpadEnd) {
-		hash_state02 = aesenc_zvkned(hash_state02, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + 0, stride, 8));
-		hash_state13 = aesdec_zvkned(hash_state13, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + 4, stride, 8), zero);
+		hash_state02 = aesenc_zvkned(hash_state02, load_lane_pair(scratchpadPtr,  0, 32));
+		hash_state13 = aesdec_zvkned(hash_state13, load_lane_pair(scratchpadPtr, 16, 48), zero);
 
 		fill_state02 = aesdec_zvkned(fill_state02, key02, zero);
 		fill_state13 = aesenc_zvkned(fill_state13, key13);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + 0, stride, fill_state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + 4, stride, fill_state13, 8);
+		// the fill states may only be written after the hash states above have
+		// read the old contents of this block
+		store_lane_pair(scratchpadPtr,  0, 32, fill_state02);
+		store_lane_pair(scratchpadPtr, 16, 48, fill_state13);
 
 		scratchpadPtr += 64;
 	}

--- a/src/crypto/randomx/jit_compiler_rv64.cpp
+++ b/src/crypto/randomx/jit_compiler_rv64.cpp
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <climits>
 #include <cassert>
 #include "backend/cpu/Cpu.h"
+#include "backend/cpu/platform/riscv_vlen.h"
 #include "crypto/randomx/jit_compiler_rv64.hpp"
 #include "crypto/randomx/jit_compiler_rv64_static.hpp"
 #include "crypto/randomx/jit_compiler_rv64_vector.h"
@@ -645,7 +646,10 @@ namespace randomx {
 		//jal x1, SuperscalarHash
 		emitJump(state, ReturnReg, LiteralPoolSize + offsetFixDataCall, SuperScalarHashOffset);
 
-		if (xmrig::Cpu::info()->hasRISCV_Vector()) {
+		// The vector kernels assume VLMAX >= 4 at e64/LMUL=1. On a smaller vector
+		// unit vl gets clamped and the generated code would compute garbage, so
+		// fall back to the scalar entry points instead.
+		if (xmrig::riscv_vlen() >= xmrig::RISCV_MIN_VLEN) {
 			vectorCodeSize = ((uint8_t*)randomx_riscv64_vector_code_end) - ((uint8_t*)randomx_riscv64_vector_code_begin);
 			vectorCode = static_cast<uint8_t*>(allocExecutableMemory(vectorCodeSize, hugePagesJIT && hugePagesEnable));
 

--- a/src/crypto/randomx/jit_compiler_rv64_vector_static.S
+++ b/src/crypto/randomx/jit_compiler_rv64_vector_static.S
@@ -100,8 +100,6 @@ sshash_constant_4: .dword 5281919268842080866
 sshash_constant_5: .dword 10536153434571861004
 sshash_constant_6: .dword 3398623926847679864
 sshash_constant_7: .dword 9549104520008361294
-sshash_offsets:    .dword 0,1,2,3
-store_offsets:     .dword 0,64,128,192
 
 DECL(randomx_riscv64_vector_sshash_imul_rcp_literals): .fill 512,8,0
 
@@ -111,6 +109,8 @@ Reference: https://github.com/tevador/RandomX/blob/master/doc/specs.md#73-datase
 Register layout
 ---------------
 x5	= temporary
+x6	= prefetch loop counter
+x7	= prefetch address scratch buffer
 
 x10	= randomx cache
 x11	= output buffer
@@ -119,6 +119,9 @@ x13	= endBlock
 
 x14	= cache mask
 x15	= imul_rcp literal pointer
+
+x28	= dataset items processed per iteration (vl)
+x29	= prefetch scratch walking pointer
 
 v0-v7	= r0-r7
 v8	= itemNumber
@@ -132,8 +135,15 @@ v19	= dataset item store offsets
 */
 
 DECL(randomx_riscv64_vector_sshash_dataset_init):
-	// Process 4 64-bit values at a time
-	vsetivli zero, 4, e64, m1, ta, ma
+	// One dataset item per vector element, so the number of items processed per
+	// iteration is VLMAX at e64/LMUL=1: 4 items on a 256-bit vector unit, 16 on
+	// a 1024-bit one.
+	vsetvli x28, x0, e64, m1, ta, ma
+
+	// Scratch space for the cache prefetch addresses, 8 bytes per element.
+	// 512 bytes covers VLEN up to 4096.
+	addi sp, sp, -512
+	mv x7, sp
 
 	// Load cache->memory pointer
 	ld x10, (x10)
@@ -141,13 +151,12 @@ DECL(randomx_riscv64_vector_sshash_dataset_init):
 	// Init cache mask
 	li x14, RANDOMX_CACHE_MASK
 
-	// Init dataset item store offsets
-	lla x5, store_offsets
-	vle64.v v19, (x5)
+	// Init dataset item store offsets to (0, 64, 128, ...)
+	vid.v v19
+	vsll.vi v19, v19, 6
 
-	// Init itemNumber vector to (startBlock, startBlock + 1, startBlock + 2, startBlock + 3)
-	lla x5, sshash_offsets
-	vle64.v v8, (x5)
+	// Init itemNumber vector to (startBlock, startBlock + 1, startBlock + 2, ...)
+	vid.v v8
 	vadd.vx v8, v8, x12
 
 	// Load constants (stride = x0 = 0, so a 64-bit value will be broadcast into each element of a vector)
@@ -181,6 +190,13 @@ DECL(randomx_riscv64_vector_sshash_dataset_init):
 	add x13, x13, x11
 
 init_item:
+	// vl = min(items left, VLMAX), and x28 = that count. Recomputing it per
+	// group keeps the last iteration from running past the end when the item
+	// count is not a multiple of VLMAX.
+	sub x6, x13, x11
+	srli x6, x6, 6
+	vsetvli x28, x6, e64, m1, ta, ma
+
 	// Step 1. Init r0-r7
 
 	// r0 = (itemNumber + 1) * 6364136223846793005
@@ -239,11 +255,13 @@ DECL(randomx_riscv64_vector_sshash_generated_instructions_end):
 	add x5, x11, 56
 	vsuxei64.v v7, (x5), v19
 
-	// Iterate to the next 4 items
-	vadd.vi v8, v8, 4
-	add x11, x11, 256
+	// Iterate to the next group of items
+	vadd.vx v8, v8, x28
+	slli x5, x28, 6
+	add x11, x11, x5
 	bltu x11, x13, init_item
 
+	addi sp, sp, 512
 	ret
 
 // Step 4. Load a 64-byte item from the Cache. The item index is given by cacheIndex modulo the total number of 64-byte items in Cache.
@@ -253,40 +271,22 @@ DECL(randomx_riscv64_vector_sshash_cache_prefetch):
 	vsll.vi v9, v9, 6
 	vadd.vx v9, v9, x10
 
-	// Prefetch element 0
-	vmv.x.s x5, v9
+	// Prefetch every element. The addresses are spilled to the scratch buffer
+	// and reloaded because extracting them in registers costs one full-width
+	// vslidedown per element, which does not scale with VLEN.
+	vse64.v v9, (x7)
+	mv x29, x7
+	mv x6, x28
+1:
+	ld x5, (x29)
 #ifdef __riscv_zicbop
 	prefetch.r (x5)
 #else
 	ld x5, (x5)
 #endif
-
-	// Prefetch element 1
-	vslidedown.vi v18, v9, 1
-	vmv.x.s x5, v18
-#ifdef __riscv_zicbop
-	prefetch.r (x5)
-#else
-	ld x5, (x5)
-#endif
-
-	// Prefetch element 2
-	vslidedown.vi v18, v9, 2
-	vmv.x.s x5, v18
-#ifdef __riscv_zicbop
-	prefetch.r (x5)
-#else
-	ld x5, (x5)
-#endif
-
-	// Prefetch element 3
-	vslidedown.vi v18, v9, 3
-	vmv.x.s x5, v18
-#ifdef __riscv_zicbop
-	prefetch.r (x5)
-#else
-	ld x5, (x5)
-#endif
+	addi x29, x29, 8
+	addi x6, x6, -1
+	bnez x6, 1b
 
 	// v9 = byte offset into cache->memory
 	vsub.vx v9, v9, x10


### PR DESCRIPTION
Every RVV path now checks the vector length of the calling thread instead of assuming it is at least 256 bits, which also fixes silently wrong hashes on narrower vector units. VLEN is read per thread because it is a per-hart property and need not be uniform across a system ( Take the SpacemiT K3, for example; this chip features two clusters, but they differ in VLEN. ) .

The vectorized dataset init scales with the actual vector length instead of a fixed four lanes, and the RVV AES kernels no longer use indexed loads and stores.

Also fixes an out-of-bounds write in the vectorized dataset init when the item count is not a multiple of the lane count.

Measured on a SpacemiT K3 (rx/0, --bench=250K), hash sums unchanged:

  X100 (VLEN 256):   518.4 -> 536.8 H/s
  A100 (VLEN 1024):  186.1 -> 229.1 H/s, dataset init 29.8 s -> 15.5 s