### PR TITLE
RISC-V: avoid indexed loads/stores in the RVV AES kernels

### DIFF
--- a/src/crypto/randomx/aes_hash_rv64_vector.cpp
+++ b/src/crypto/randomx/aes_hash_rv64_vector.cpp
@@ -69,6 +69,26 @@ static constexpr uint32_t AES_HASH_1R_XKEY11[8] = { 0x61b263d1, 0x51f4e03c, 0xee
 static constexpr uint32_t AES_HASH_STRIDE_X2[8] = { 0, 4, 8, 12, 32, 36, 40, 44 };
 static constexpr uint32_t AES_HASH_STRIDE_X4[8] = { 0, 4, 8, 12, 64, 68, 72, 76 };
 
+/*
+	The four 16-byte AES lanes sit consecutively in memory, but the kernels need
+	them grouped as {0,2} and {1,3}. An indexed access does that in one
+	instruction, but indexed accesses are an order of magnitude slower than
+	unit-stride ones on both SpacemiT cores, so pick the halves up separately and
+	glue them together with a slide instead.
+*/
+static FORCE_INLINE vuint32m1_t load_lane_pair(const uint8_t* p, size_t lo, size_t hi)
+{
+	return __riscv_vslideup_vx_u32m1(
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + lo), 4),
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + hi), 4), 4, 8);
+}
+
+static FORCE_INLINE void store_lane_pair(uint8_t* p, size_t lo, size_t hi, vuint32m1_t v)
+{
+	__riscv_vse32_v_u32m1((uint32_t*)(p + lo), v, 4);
+	__riscv_vse32_v_u32m1((uint32_t*)(p + hi), __riscv_vslidedown_vx_u32m1(v, 4, 4), 4);
+}
+
 #define lutEnc0 lutEnc[0]
 #define lutEnc1 lutEnc[1]
 #define lutEnc2 lutEnc[2]
@@ -87,8 +107,6 @@ void hashAes1Rx4_RVV(const void *input, size_t inputSize, void *hash) {
 	vuint32m1_t state02 = __riscv_vle32_v_u32m1(AES_HASH_1R_STATE02, 8);
 	vuint32m1_t state13 = __riscv_vle32_v_u32m1(AES_HASH_1R_STATE13, 8);
 
-	const vuint32m1_t stride = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X2, 8);
-
 	const vuint8m1_t lutenc_index0 = __riscv_vle8_v_u8m1(lutEncIndex[0], 32);
 	const vuint8m1_t lutenc_index1 = __riscv_vle8_v_u8m1(lutEncIndex[1], 32);
 	const vuint8m1_t lutenc_index2 = __riscv_vle8_v_u8m1(lutEncIndex[2], 32);
@@ -101,8 +119,8 @@ void hashAes1Rx4_RVV(const void *input, size_t inputSize, void *hash) {
 
 	//process 64 bytes at a time in 4 lanes
 	while (inptr < inputEnd) {
-		state02 = softaes_vector_double(state02, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 0, stride, 8), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
-		state13 = softaes_vector_double(state13, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 4, stride, 8), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
+		state02 = softaes_vector_double(state02, load_lane_pair(inptr,  0, 32), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
+		state13 = softaes_vector_double(state13, load_lane_pair(inptr, 16, 48), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 
 		inptr += 64;
 	}
@@ -118,12 +136,12 @@ void hashAes1Rx4_RVV(const void *input, size_t inputSize, void *hash) {
 	state13 = softaes_vector_double(state13, xkey11, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 
 	//output hash
-	__riscv_vsuxei32_v_u32m1((uint32_t*)hash + 0, stride, state02, 8);
-	__riscv_vsuxei32_v_u32m1((uint32_t*)hash + 4, stride, state13, 8);
+	store_lane_pair((uint8_t*)hash,  0, 32, state02);
+	store_lane_pair((uint8_t*)hash, 16, 48, state13);
 }
 
 void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t key02 = __riscv_vle32_v_u32m1(AES_GEN_1R_KEY02, 8);
@@ -148,8 +166,8 @@ void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 		state02 = softaes_vector_double(state02, key02, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 		state13 = softaes_vector_double(state13, key13, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -159,7 +177,7 @@ void fillAes1Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 }
 
 void fillAes4Rx4_RVV(void *state, size_t outputSize, void *buffer) {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t stride4 = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X4, 8);
@@ -197,8 +215,8 @@ void fillAes4Rx4_RVV(void *state, size_t outputSize, void *buffer) {
 		state02 = softaes_vector_double(state02, key37, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 		state13 = softaes_vector_double(state13, key37, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -232,14 +250,14 @@ void hashAndFillAes1Rx4_RVV(void *scratchpad, size_t scratchpadSize, void *hash,
 	//process 64 bytes at a time in 4 lanes
 	while (scratchpadPtr < scratchpadEnd) {
 #define HASH_STATE(k) \
-		hash_state02 = softaes_vector_double(hash_state02, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 0, stride, 8), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
-		hash_state13 = softaes_vector_double(hash_state13, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 4, stride, 8), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
+		hash_state02 = softaes_vector_double(hash_state02, load_lane_pair(scratchpadPtr + k * 64,  0, 32), lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
+		hash_state13 = softaes_vector_double(hash_state13, load_lane_pair(scratchpadPtr + k * 64, 16, 48), lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3);
 
 #define FILL_STATE(k) \
 		fill_state02 = softaes_vector_double(fill_state02, key02, lutdec_index0, lutdec_index1, lutdec_index2, lutdec_index3, lutDec0, lutDec1, lutDec2, lutDec3); \
 		fill_state13 = softaes_vector_double(fill_state13, key13, lutenc_index0, lutenc_index1, lutenc_index2, lutenc_index3, lutEnc0, lutEnc1, lutEnc2, lutEnc3); \
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 0, stride, fill_state02, 8); \
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + k * 16 + 4, stride, fill_state13, 8);
+		store_lane_pair(scratchpadPtr + k * 64,  0, 32, fill_state02); \
+		store_lane_pair(scratchpadPtr + k * 64, 16, 48, fill_state13);
 
 		HASH_STATE(0);
 		HASH_STATE(1);

--- a/src/crypto/randomx/aes_hash_rv64_zvkned.cpp
+++ b/src/crypto/randomx/aes_hash_rv64_zvkned.cpp
@@ -36,6 +36,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static FORCE_INLINE vuint32m1_t aesenc_zvkned(vuint32m1_t a, vuint32m1_t b) { return __riscv_vaesem_vv_u32m1(a, b, 8); }
 static FORCE_INLINE vuint32m1_t aesdec_zvkned(vuint32m1_t a, vuint32m1_t b, vuint32m1_t zero) { return __riscv_vxor_vv_u32m1(__riscv_vaesdm_vv_u32m1(a, zero, 8), b, 8); }
 
+/*
+	The four 16-byte AES lanes sit consecutively in memory, but the kernels need
+	them grouped as {0,2} and {1,3} because those pairs share an AES direction.
+	An indexed access does the regrouping in a single instruction, which is what
+	the strided AES_HASH_STRIDE_X2 index vector is for - but indexed accesses are
+	an order of magnitude slower than unit-stride ones on both SpacemiT cores
+	(gather ~16x a vle32 on X100, ~14x on A100; scatter ~8x and ~36x), so it pays
+	to pick the two halves up separately and glue them together with a slide.
+*/
+static FORCE_INLINE vuint32m1_t load_lane_pair(const uint8_t* p, size_t lo, size_t hi)
+{
+	return __riscv_vslideup_vx_u32m1(
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + lo), 4),
+		__riscv_vle32_v_u32m1((const uint32_t*)(p + hi), 4), 4, 8);
+}
+
+static FORCE_INLINE void store_lane_pair(uint8_t* p, size_t lo, size_t hi, vuint32m1_t v)
+{
+	__riscv_vse32_v_u32m1((uint32_t*)(p + lo), v, 4);
+	__riscv_vse32_v_u32m1((uint32_t*)(p + hi), __riscv_vslidedown_vx_u32m1(v, 4, 4), 4);
+}
+
 static constexpr uint32_t AES_HASH_1R_STATE02[8] = { 0x92b52c0d, 0x9fa856de, 0xcc82db47, 0xd7983aad, 0x6a770017, 0xae62c7d0, 0x5079506b, 0xe8a07ce4 };
 static constexpr uint32_t AES_HASH_1R_STATE13[8] = { 0x338d996e, 0x15c7b798, 0xf59e125a, 0xace78057, 0x630a240c, 0x07ad828d, 0x79a10005, 0x7e994948 };
 
@@ -57,13 +79,12 @@ void hashAes1Rx4_zvkned(const void *input, size_t inputSize, void *hash)
 	vuint32m1_t state02 = __riscv_vle32_v_u32m1(AES_HASH_1R_STATE02, 8);
 	vuint32m1_t state13 = __riscv_vle32_v_u32m1(AES_HASH_1R_STATE13, 8);
 
-	const vuint32m1_t stride = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X2, 8);
 	const vuint32m1_t zero = {};
 
 	//process 64 bytes at a time in 4 lanes
 	while (inptr < inputEnd) {
-		state02 = aesenc_zvkned(state02, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 0, stride, 8));
-		state13 = aesdec_zvkned(state13, __riscv_vluxei32_v_u32m1((uint32_t*)inptr + 4, stride, 8), zero);
+		state02 = aesenc_zvkned(state02, load_lane_pair(inptr,  0, 32));
+		state13 = aesdec_zvkned(state13, load_lane_pair(inptr, 16, 48), zero);
 
 		inptr += 64;
 	}
@@ -79,13 +100,13 @@ void hashAes1Rx4_zvkned(const void *input, size_t inputSize, void *hash)
 	state13 = aesdec_zvkned(state13, xkey11, zero);
 
 	//output hash
-	__riscv_vsuxei32_v_u32m1((uint32_t*)hash + 0, stride, state02, 8);
-	__riscv_vsuxei32_v_u32m1((uint32_t*)hash + 4, stride, state13, 8);
+	store_lane_pair((uint8_t*)hash,  0, 32, state02);
+	store_lane_pair((uint8_t*)hash, 16, 48, state13);
 }
 
 void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t key02 = __riscv_vle32_v_u32m1(AES_GEN_1R_KEY02, 8);
@@ -101,8 +122,8 @@ void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 		state02 = aesdec_zvkned(state02, key02, zero);
 		state13 = aesenc_zvkned(state13, key13);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -113,7 +134,7 @@ void fillAes1Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 
 void fillAes4Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 {
-	const uint8_t* outptr = (uint8_t*)buffer;
+	uint8_t* outptr = (uint8_t*)buffer;
 	const uint8_t* outputEnd = outptr + outputSize;
 
 	const vuint32m1_t stride4 = __riscv_vle32_v_u32m1(AES_HASH_STRIDE_X4, 8);
@@ -142,8 +163,8 @@ void fillAes4Rx4_zvkned(void *state, size_t outputSize, void *buffer)
 		state02 = aesdec_zvkned(state02, key37, zero);
 		state13 = aesenc_zvkned(state13, key37);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 0, stride, state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)outptr + 4, stride, state13, 8);
+		store_lane_pair(outptr,  0, 32, state02);
+		store_lane_pair(outptr, 16, 48, state13);
 
 		outptr += 64;
 	}
@@ -168,14 +189,16 @@ void hashAndFillAes1Rx4_zvkned(void *scratchpad, size_t scratchpadSize, void *ha
 
 	//process 64 bytes at a time in 4 lanes
 	while (scratchpadPtr < scratchpadEnd) {
-		hash_state02 = aesenc_zvkned(hash_state02, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + 0, stride, 8));
-		hash_state13 = aesdec_zvkned(hash_state13, __riscv_vluxei32_v_u32m1((uint32_t*)scratchpadPtr + 4, stride, 8), zero);
+		hash_state02 = aesenc_zvkned(hash_state02, load_lane_pair(scratchpadPtr,  0, 32));
+		hash_state13 = aesdec_zvkned(hash_state13, load_lane_pair(scratchpadPtr, 16, 48), zero);
 
 		fill_state02 = aesdec_zvkned(fill_state02, key02, zero);
 		fill_state13 = aesenc_zvkned(fill_state13, key13);
 
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + 0, stride, fill_state02, 8);
-		__riscv_vsuxei32_v_u32m1((uint32_t*)scratchpadPtr + 4, stride, fill_state13, 8);
+		// the fill states may only be written after the hash states above have
+		// read the old contents of this block
+		store_lane_pair(scratchpadPtr,  0, 32, fill_state02);
+		store_lane_pair(scratchpadPtr, 16, 48, fill_state13);
 
 		scratchpadPtr += 64;
 	}


### PR DESCRIPTION
The four 16-byte AES lanes are consecutive in memory but the kernels need them grouped as {0,2} and {1,3}, which the strided AES_HASH_STRIDE_X2 index vector did in a single indexed access. Indexed accesses turn out to be an order of magnitude slower than unit-stride ones on both SpacemiT cores (SpacemiT K3 chip) , so pick the two halves up separately and glue them together with a slide.

Measured with 8 independent destination registers, AVL=8, e32/LMUL=1:

X100 (VLEN 256)   A100 (VLEN 1024)
  vluxei32 (gather)          7.28 ns          129.8 ns
  vsuxei32 (scatter)         7.28 ns           59.7 ns
  vle32  (unit-stride)       0.46 ns            9.46 ns
  vse32  (unit-stride)       0.91 ns            1.67 ns
  vslideup.vi                0.91 ns            4.45 ns

Applied to the hot loops of all four kernels. The remaining indexed accesses run once per call on a 64-byte state buffer and are amortized over a 2 MB fill, so they are left alone.

hashAndFillAes1Rx4 throughput on a SpacemiT K3:

  X100 (VLEN 256):   2.16 -> 4.62 GB/s  (2.14x)
  A100 (VLEN 1024):  0.21 -> 0.64 GB/s  (3.05x)

End to end, --bench=250K -t 8 on the K3 X100 cluster (VLEN 256), two runs of each build, alternating order:

  before   594.1, 593.4 h/s
  after    620.2, 621.6 h/s   (+4.6%)
  
This PR is a split-out commit from https://github.com/xmrig/xmrig/pull/3839.
cc @SChernykh 